### PR TITLE
#27-fix-git-workflow-version-and-changelog feat: add support to orderBt

### DIFF
--- a/sparkleframe/polarsdf/column.py
+++ b/sparkleframe/polarsdf/column.py
@@ -140,11 +140,6 @@ class Column:
 
         return Column(self.expr.str.contains(pattern))
 
-    def _sort(self, col: str, descending: bool) -> Column:
-        self._sort_col = col
-        self._sort_descending = descending
-        return self
-
     def to_native(self) -> pl.Expr:
         return self.expr
 

--- a/sparkleframe/polarsdf/functions.py
+++ b/sparkleframe/polarsdf/functions.py
@@ -302,9 +302,53 @@ def asc(column: Union[str, Column]) -> Column:
     Returns:
         Column: A Column object representing ascending order sort expression.
     """
+    descending = False
+    nulls_last = False
     col_expr = _to_expr(col(column)) if isinstance(column, str) else column.to_native()
-    column_ = Column(col_expr.sort(descending=False))
-    return column_._sort(col=col_expr, descending=False)
+    column_ = Column(col_expr.sort(descending=descending, nulls_last=nulls_last))
+    column_._sort_col = col_expr
+    column_._sort_descending = descending
+    column_._sort_nulls_last = nulls_last
+    return column_
+
+
+def asc_nulls_first(column: Union[str, Column]) -> Column:
+    """
+    Mimics pyspark.sql.functions.asc_nulls_first.
+
+    Specifies ascending sort order with nulls first for the column.
+
+    Args:
+        column (str or Column): The column to sort in ascending order.
+
+    Returns:
+        Column: A Column object representing ascending order sort expression with nulls first.
+    """
+
+    return asc(column)
+
+
+def asc_nulls_last(column: Union[str, Column]) -> Column:
+    """
+    Mimics pyspark.sql.functions.asc_nulls_last.
+
+    Specifies ascending sort order with nulls last for the column.
+
+    Args:
+        column (str or Column): The column to sort in ascending order.
+
+    Returns:
+        Column: A Column object representing ascending order sort expression with nulls last.
+    """
+
+    descending = False
+    nulls_last = True
+    col_expr = _to_expr(col(column)) if isinstance(column, str) else column.to_native()
+    column_ = Column(col_expr.sort(descending=descending, nulls_last=nulls_last))
+    column_._sort_col = col_expr
+    column_._sort_descending = descending
+    column_._sort_nulls_last = nulls_last
+    return column_
 
 
 def desc(column: Union[str, Column]) -> Column:
@@ -319,9 +363,53 @@ def desc(column: Union[str, Column]) -> Column:
     Returns:
         Column: A Column object representing descending order sort expression.
     """
+    descending = True
+    nulls_last = True
     col_expr = _to_expr(col(column)) if isinstance(column, str) else column.to_native()
-    column_ = Column(col_expr.sort(descending=True))
-    return column_._sort(col=col_expr, descending=True)
+    column_ = Column(col_expr.sort(descending=descending, nulls_last=nulls_last))
+    column_._sort_col = col_expr
+    column_._sort_descending = descending
+    column_._sort_nulls_last = nulls_last
+    return column_
+
+
+def desc_nulls_first(column: Union[str, Column]) -> Column:
+    """
+    Mimics pyspark.sql.functions.desc_nulls_first.
+
+    Specifies descending sort order with nulls first for the column.
+
+    Args:
+        column (str or Column): The column to sort in descending order.
+
+    Returns:
+        Column: A Column object representing descending order sort expression with nulls first.
+    """
+
+    descending = True
+    nulls_last = False
+    col_expr = _to_expr(col(column)) if isinstance(column, str) else column.to_native()
+    column_ = Column(col_expr.sort(descending=descending, nulls_last=nulls_last))
+    column_._sort_col = col_expr
+    column_._sort_descending = descending
+    column_._sort_nulls_last = nulls_last
+    return column_
+
+
+def desc_nulls_last(column: Union[str, Column]) -> Column:
+    """
+    Mimics pyspark.sql.functions.desc_nulls_last.
+
+    Specifies descending sort order with nulls last for the column.
+
+    Args:
+        column (str or Column): The column to sort in descending order.
+
+    Returns:
+        Column: A Column object representing descending order sort expression with nulls last.
+    """
+
+    return desc(column)
 
 
 def rank() -> Column:


### PR DESCRIPTION
#27-fix-git-workflow-version-and-changelog feat: add support to orderBy with asc, asc_nulls_first, asc_nulls_last, desc, desc_nulls_first, desc_nulls_last