### PR TITLE
feat: struct, collect_list, uuid, drop, try_to_*, try_cast, concat

### DIFF
--- a/sparkleframe/polarsdf/column.py
+++ b/sparkleframe/polarsdf/column.py
@@ -5,7 +5,7 @@ from typing import Union
 
 import polars as pl
 
-from sparkleframe.polarsdf.types import DataType
+from sparkleframe.polarsdf.types import DataType, spark_type_name_to_polars
 
 
 class Column:
@@ -97,6 +97,28 @@ class Column:
         if not isinstance(data_type, DataType):
             raise TypeError(f"cast() expects a DataType, got {type(data_type)}")
         return Column(self.expr.cast(data_type.to_native()))
+
+    def try_cast(self, data_type: Union[DataType, str]) -> "Column":
+        """
+        Mimics pyspark.sql.Column.try_cast (Spark 4+).
+
+        Attempts to cast the column to the target type; returns null instead
+        of raising an error when the value cannot be converted.
+
+        Args:
+            data_type (DataType or str): Target type as a sparkleframe DataType
+                or a Spark type-name string (e.g. "int", "double", "string").
+
+        Returns:
+            Column: A new Column with the non-strict cast applied.
+        """
+        if isinstance(data_type, DataType):
+            native = data_type.to_native()
+        elif isinstance(data_type, str):
+            native = spark_type_name_to_polars(data_type)
+        else:
+            raise TypeError(f"try_cast() expects a DataType or str, got {type(data_type)}")
+        return Column(self.expr.cast(native, strict=False))
 
     def isin(self, *values) -> Column:
         """

--- a/sparkleframe/polarsdf/column_test.py
+++ b/sparkleframe/polarsdf/column_test.py
@@ -8,6 +8,7 @@ from polars.exceptions import InvalidOperationError
 from sparkleframe.polarsdf import DataFrame, StringType
 from sparkleframe.polarsdf.functions import col, lit
 from sparkleframe.polarsdf.types import (
+    SPARK_TYPE_NAME_MAP,
     BinaryType,
     BooleanType,
     ByteType,
@@ -156,6 +157,56 @@ class TestColumn:
 
         # Assert the column's dtype is as expected
         assert result_df.to_native_df().schema["casted"] == expected_polars_dtype
+
+    # ---- try_cast tests ----
+
+    @pytest.mark.parametrize(
+        "data_type_class",
+        [
+            StringType,
+            IntegerType,
+            LongType,
+            FloatType,
+            DoubleType,
+            BooleanType,
+        ],
+    )
+    def test_try_cast_datatype_valid(self, sample_df, data_type_class):
+        expected_polars_dtype = data_type_class().to_native()
+        expr = col("a").try_cast(data_type_class())
+        result_df = DataFrame(sample_df).select(expr.alias("casted"))
+        assert result_df.to_native_df().schema["casted"] == expected_polars_dtype
+
+    @pytest.mark.parametrize(
+        "type_name",
+        [
+            "string",
+            "int",
+            "integer",
+            "bigint",
+            "long",
+            "double",
+            "float",
+            "boolean",
+            "date",
+            "timestamp",
+        ],
+    )
+    def test_try_cast_string_type_name(self, sample_df, type_name: str):
+        expected_polars_dtype = SPARK_TYPE_NAME_MAP[type_name]
+        expr = col("a").try_cast(type_name)
+        result_df = DataFrame(sample_df).select(expr.alias("casted"))
+        assert result_df.to_native_df().schema["casted"] == expected_polars_dtype
+
+    def test_try_cast_invalid_returns_null(self):
+        df = pl.DataFrame({"name": ["123", "Bob", None]})
+        result = DataFrame(df).select(col("name").try_cast(LongType()).alias("v")).to_native_df()
+        assert result["v"].to_list() == [123, None, None]
+
+    def test_try_cast_string_invalid_returns_null(self):
+        df = pl.DataFrame({"name": ["123", "Bob", None]})
+        result = DataFrame(df).select(col("name").try_cast("double").alias("v")).to_native_df()
+        assert result["v"].to_list() == [123.0, None, None]
 
     def test_is_not_null(self):
         df = pl.DataFrame({"x": [1, None, 3, None, 5]})

--- a/sparkleframe/polarsdf/dataframe.py
+++ b/sparkleframe/polarsdf/dataframe.py
@@ -258,6 +258,41 @@ class DataFrame(BaseDataFrame):
         renamed_df = self.df.rename({existing: new})
         return DataFrame(renamed_df)
 
+    def drop(self, *cols: Union[str, Column]) -> "DataFrame":
+        """
+        Mimics PySpark's DataFrame.drop.
+
+        Removes the given columns. Columns that are not in the schema are ignored
+        (same as PySpark). With no arguments, returns a new DataFrame wrapper over
+        the same underlying Polars frame (same pattern as ``select`` / ``sort``).
+
+        Args:
+            *cols: Column names as strings or Column references (e.g. ``col("x")``).
+                Use ``df.drop(*["a", "b"])`` to drop from a list (same as PySpark).
+
+        Returns:
+            DataFrame: A new DataFrame without the dropped columns.
+        """
+        if not cols:
+            return DataFrame(self.df)
+
+        to_drop: List[str] = []
+        for c in cols:
+            if isinstance(c, str):
+                to_drop.append(c)
+            elif isinstance(c, Column):
+                roots = c.to_native().meta.root_names()
+                if not roots:
+                    raise TypeError("drop() Column expression must reference a named column")
+                to_drop.append(roots[0])
+            else:
+                raise TypeError(f"drop() expected str or Column, got {type(c).__name__}")
+
+        existing = [name for name in to_drop if name in self.df.columns]
+        if not existing:
+            return DataFrame(self.df)
+        return DataFrame(self.df.drop(*existing))
+
     def toPandas(self) -> pd.DataFrame:
         """
         Convert the underlying Polars DataFrame to a Pandas DataFrame,

--- a/sparkleframe/polarsdf/dataframe_test.py
+++ b/sparkleframe/polarsdf/dataframe_test.py
@@ -212,6 +212,33 @@ class TestDataFrame:
 
         assert_pyspark_df_equal(result_spark_df, expected_spark_df)
 
+    def test_drop_columns(self, spark, sparkle_df, spark_df):
+        result_spark_df = spark.createDataFrame(sparkle_df.drop("salary", "birth_date").toPandas())
+        expected_spark_df = spark_df.drop("salary", "birth_date")
+        assert_pyspark_df_equal(result_spark_df, expected_spark_df, ignore_nullable=True)
+
+    def test_drop_unpack_list(self, spark, sparkle_df, spark_df):
+        result_spark_df = spark.createDataFrame(sparkle_df.drop(*["salary", "age"]).toPandas())
+        expected_spark_df = spark_df.drop(*["salary", "age"])
+        assert_pyspark_df_equal(result_spark_df, expected_spark_df, ignore_nullable=True)
+
+    def test_drop_column_expr(self, spark, sparkle_df, spark_df):
+        result_spark_df = spark.createDataFrame(sparkle_df.drop(PF.col("salary")).toPandas())
+        expected_spark_df = spark_df.drop(F.col("salary"))
+        assert_pyspark_df_equal(result_spark_df, expected_spark_df, ignore_nullable=True)
+
+    def test_drop_missing_column_ignored(self, spark, sparkle_df, spark_df):
+        result_spark_df = spark.createDataFrame(sparkle_df.drop("not_there", "age").toPandas())
+        expected_spark_df = spark_df.drop("not_there", "age")
+        assert_pyspark_df_equal(result_spark_df, expected_spark_df, ignore_nullable=True)
+
+    def test_drop_no_args_returns_new_wrapper_same_polars_df(self, sparkle_df):
+        out = sparkle_df.drop()
+        assert out is not sparkle_df
+        assert out.columns == sparkle_df.columns
+        assert out.df is sparkle_df.df
+        assert out.to_native_df().equals(sparkle_df.to_native_df())
+
     def test_to_native_df(self, sparkle_df):
         native_df = sparkle_df.to_native_df()
 

--- a/sparkleframe/polarsdf/dataframe_test.py
+++ b/sparkleframe/polarsdf/dataframe_test.py
@@ -538,6 +538,64 @@ class TestDataFrame:
         expected_df = expected_df.withColumn("agg_result", F.col("agg_result").cast("float"))
         assert_pyspark_df_equal(result_spark_df.orderBy("group"), expected_df.orderBy("group"), ignore_nullable=True)
 
+    @pytest.mark.parametrize("use_alias", [False, True])
+    def test_groupby_collect_list(self, spark, use_alias):
+        """collect_list matches Spark; rows are ordered so list order is deterministic."""
+        data = {
+            "group": ["A", "A", "A", "B", "B"],
+            "value": [3, None, 1, 2, None],
+        }
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys())).orderBy(
+            "group", F.asc_nulls_last("value")
+        )
+        pl_df = DataFrame(pl.DataFrame(data)).sort("group", PF.asc_nulls_last("value"))
+
+        if not use_alias:
+            expected_df = spark_df.groupBy("group")
+            result_df = pl_df.groupBy("group")
+        else:
+            expected_df = spark_df.groupby("group")
+            result_df = pl_df.groupby("group")
+
+        expected_df = expected_df.agg(F.collect_list("value").alias("agg_result"))
+        result_df = result_df.agg(PF.collect_list("value").alias("agg_result"))
+
+        result_spark_df = spark.createDataFrame(result_df.toPandas())
+        assert_pyspark_df_equal(result_spark_df.orderBy("group"), expected_df.orderBy("group"), ignore_nullable=True)
+
+    def test_groupby_collect_list_nested_aliased_struct(self, spark):
+        """collect_list(struct(...)) preserves aliased nested struct field names (not col1/col2)."""
+        rows = [
+            {"group_id": "g1", "c1": "u", "c2": 10, "c3": "w"},
+            {"group_id": "g1", "c1": "v", "c2": 20, "c3": "z"},
+        ]
+        spark_base = spark.createDataFrame(rows)
+        spark_item_expr = F.struct(
+            F.struct(F.col("c1"), F.col("c2")).alias("nested_x"),
+            F.struct(F.col("c3").alias("leaf")).alias("nested_y"),
+        ).alias("item")
+        expected_df = (
+            spark_base.withColumn("item", spark_item_expr)
+            .orderBy("group_id", "c1")
+            .groupBy("group_id")
+            .agg(F.collect_list("item").alias("items"))
+        )
+        pl_base = DataFrame(pl.DataFrame(rows))
+        pl_item_expr = PF.struct(
+            PF.struct(PF.col("c1"), PF.col("c2")).alias("nested_x"),
+            PF.struct(PF.col("c3").alias("leaf")).alias("nested_y"),
+        ).alias("item")
+        result_df = (
+            pl_base.withColumn("item", pl_item_expr)
+            .sort("group_id", "c1")
+            .groupBy("group_id")
+            .agg(PF.collect_list("item").alias("items"))
+        )
+        result_spark_df = spark.createDataFrame(result_df.toPandas(), schema=expected_df.schema)
+        assert_pyspark_df_equal(
+            result_spark_df.orderBy("group_id"), expected_df.orderBy("group_id"), ignore_nullable=True
+        )
+
     @pytest.mark.parametrize(
         "how,on_input,expected",
         [

--- a/sparkleframe/polarsdf/functions.py
+++ b/sparkleframe/polarsdf/functions.py
@@ -165,6 +165,23 @@ def max(col_name: Union[str, Column]) -> Column:
     return Column(expr.max())
 
 
+def collect_list(col_name: Union[str, Column]) -> Column:
+    """
+    Mimics pyspark.sql.functions.collect_list.
+
+    Collects values into a list per group when used with ``groupBy`` / ``agg``.
+    Null values are omitted from the list, matching PySpark.
+
+    Args:
+        col_name (str or Column): The column whose values are collected.
+
+    Returns:
+        Column: A Column representing the list aggregation expression.
+    """
+    expr = _to_expr(col_name) if isinstance(col_name, Column) else pl.col(col_name)
+    return Column(expr.filter(expr.is_not_null()).implode())
+
+
 def round(col_name: Union[str, Column], scale: int = 0) -> Column:
     """
     Mimics pyspark.sql.functions.round.

--- a/sparkleframe/polarsdf/functions.py
+++ b/sparkleframe/polarsdf/functions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
-from typing import Union, Any
+
+from typing import Any, Union
 
 import polars as pl
 
@@ -504,3 +505,61 @@ def lower(col_name: Union[str, Column]) -> Column:
     col_name = pl.col(col_name) if isinstance(col_name, str) else col_name
     expr = _to_expr(col_name)
     return Column(expr.str.to_lowercase())
+
+
+def _struct_expand_varargs(cols: tuple[Any, ...]) -> tuple[Any, ...]:
+    """Match PySpark ``struct`` when called as ``struct([c1, c2])`` or ``struct({...})``."""
+    if len(cols) == 1 and isinstance(cols[0], (list, set)):
+        return tuple(cols[0])
+    return cols
+
+
+def _struct_child_field_name(arg: Union[str, Column], expr: pl.Expr, index: int) -> str:
+    """
+    Spark ``CreateStruct`` naming: plain column refs keep their name (last segment if qualified);
+    literals and non-trivial expressions become ``col1``, ``col2``, ...
+    """
+    if isinstance(arg, str):
+        return arg.split(".")[-1]
+    if b"RepeatBy" in expr.meta.serialize():
+        return f"col{index + 1}"
+    undone = expr.meta.undo_aliases()
+    # Explicit Alias (nested struct(...).alias("nested_x"), col().alias("z"), …): Spark uses output_name.
+    # Do not use serialize() inequality — Polars versions disagree for bare struct(); compare output names instead.
+    if expr.meta.output_name() != undone.meta.output_name():
+        return expr.meta.output_name().split(".")[-1]
+    # Alias-of-column (e.g. col("a").alias("z")) is not is_column() in Polars; Spark uses the alias name.
+    if undone.meta.is_column():
+        return expr.meta.output_name().split(".")[-1]
+    if expr.meta.is_literal():
+        return f"col{index + 1}"
+    return f"col{index + 1}"
+
+
+def _struct_named_child(arg: Union[str, Column], index: int) -> pl.Expr:
+    expr = _to_expr(arg) if isinstance(arg, Column) else pl.col(arg)
+    name = _struct_child_field_name(arg, expr, index)
+    return expr.alias(name)
+
+
+def struct(*cols: Any) -> Column:
+    """
+    Mimics pyspark.sql.functions.struct.
+
+    Builds a struct column from column names and/or Column expressions. If a single
+    list or set is passed, it is expanded like PySpark (3.4+).
+
+    Empty ``struct()`` is not supported (PySpark fails at execution).
+
+    Args:
+        *cols: Column names (``str``), :class:`~sparkleframe.polarsdf.column.Column` values,
+            or a single ``list`` / ``set`` of those.
+
+    Returns:
+        Column: A struct column whose field names follow Spark's ``CreateStruct`` rules.
+    """
+    expanded = _struct_expand_varargs(cols)
+    if not expanded:
+        raise ValueError("struct requires at least one column")
+    parts = [_struct_named_child(c, i) for i, c in enumerate(expanded)]
+    return Column(pl.struct(parts))

--- a/sparkleframe/polarsdf/functions.py
+++ b/sparkleframe/polarsdf/functions.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Union
+from typing import Any, Optional, Union
 
 import polars as pl
 
@@ -225,6 +225,52 @@ def when(condition: Any, value) -> WhenBuilder:
     return WhenBuilder(condition, value)
 
 
+_SPARK_TS_FORMAT_MAP = [
+    ("yyyy", "%Y"),
+    ("MM", "%m"),
+    ("dd", "%d"),
+    ("HH", "%H"),
+    ("mm", "%M"),
+    ("ss", "%S"),
+    (".SSSSSS", ".%6f"),
+    (".SSSSS", ".%6f"),
+    (".SSSS", ".%6f"),
+    (".SSS", ".%6f"),
+    (".SS", ".%6f"),
+    (".S", ".%6f"),
+]
+
+
+def _convert_spark_ts_format(fmt: str) -> str:
+    """Translate a Spark-style timestamp format string to strftime-style."""
+    for spark_fmt, strftime_fmt in _SPARK_TS_FORMAT_MAP:
+        fmt = fmt.replace(spark_fmt, strftime_fmt)
+    return fmt
+
+
+def _pad_microseconds_expr(expr: pl.Expr) -> pl.Expr:
+    """Normalize fractional seconds to 6 digits (microseconds)."""
+
+    def pad_microseconds(val: Optional[str]) -> Optional[str]:
+        if val is None:
+            return None
+        if "." in val:
+            prefix, suffix = val.split(".", 1)
+            suffix = (suffix + "000000")[:6]
+            return f"{prefix}.{suffix}"
+        return val
+
+    return expr.map_elements(pad_microseconds, return_dtype=pl.String)
+
+
+def _to_datetime_column(col_name: Union[str, Column], fmt: str, *, strict: bool = True) -> Column:
+    strftime_fmt = _convert_spark_ts_format(fmt)
+    expr = _to_expr(col_name) if isinstance(col_name, Column) else pl.col(col_name)
+    if "%6f" in strftime_fmt:
+        expr = _pad_microseconds_expr(expr)
+    return Column(expr.str.strptime(pl.Datetime, strftime_fmt, strict=strict))
+
+
 def to_timestamp(col_name: Union[str, Column], fmt: str = "yyyy-MM-dd HH:mm:ss") -> Column:
     """
     Mimics pyspark.sql.functions.to_timestamp.
@@ -238,44 +284,7 @@ def to_timestamp(col_name: Union[str, Column], fmt: str = "yyyy-MM-dd HH:mm:ss")
     Returns:
         Column: A Column with values converted to Polars datetime type.
     """
-    # Convert Spark-style format to strftime-style for Polars
-
-    format_map = [
-        ("yyyy", "%Y"),
-        ("MM", "%m"),
-        ("dd", "%d"),
-        ("HH", "%H"),
-        ("mm", "%M"),
-        ("ss", "%S"),
-        (".SSSSSS", ".%6f"),  # microseconds
-        (".SSSSS", ".%6f"),
-        (".SSSS", ".%6f"),
-        (".SSS", ".%6f"),  # also treated as microseconds, will pad
-        (".SS", ".%6f"),
-        (".S", ".%6f"),
-    ]
-    # Pad fractional seconds to 6 digits (microseconds)
-    for spark_fmt, strftime_fmt in format_map:
-        fmt = fmt.replace(spark_fmt, strftime_fmt)
-
-    expr = _to_expr(col_name) if isinstance(col_name, Column) else pl.col(col_name)
-
-    # Normalize fractional seconds (pad with trailing zeros to make 6 digits)
-    # appends zeros to fractional part (e.g., .993 -> .993000)
-    if "%6f" in fmt:
-        # Pad fractional seconds using a map function
-        def pad_microseconds(val):
-            if val is None:
-                return None
-            if "." in val:
-                prefix, suffix = val.split(".", 1)
-                suffix = (suffix + "000000")[:6]  # Ensure exactly 6 digits
-                return f"{prefix}.{suffix}"
-            return val
-
-        expr = expr.map_elements(pad_microseconds, return_dtype=pl.String)
-
-    return Column(expr.str.strptime(pl.Datetime, fmt))
+    return _to_datetime_column(col_name, fmt, strict=True)
 
 
 def regexp_replace(col_name: Union[str, Column], pattern: str, replacement: str) -> Column:
@@ -580,3 +589,107 @@ def struct(*cols: Any) -> Column:
         raise ValueError("struct requires at least one column")
     parts = [_struct_named_child(c, i) for i, c in enumerate(expanded)]
     return Column(pl.struct(parts))
+
+
+def try_to_timestamp(col_name: Union[str, Column], fmt: str = "yyyy-MM-dd HH:mm:ss") -> Column:
+    """
+    Mimics pyspark.sql.functions.try_to_timestamp (Spark 4+).
+
+    Same as to_timestamp but returns null instead of raising on malformed strings.
+
+    Args:
+        col_name (str or Column): Column with string values to convert to timestamps.
+        fmt (str): The timestamp format to parse the strings. Defaults to 'yyyy-MM-dd HH:mm:ss'.
+
+    Returns:
+        Column: A Column with values converted to Polars datetime type (null for failures).
+    """
+    return _to_datetime_column(col_name, fmt, strict=False)
+
+
+_SPARK_DATE_FORMAT_MAP = [
+    ("yyyy", "%Y"),
+    ("MM", "%m"),
+    ("dd", "%d"),
+]
+
+
+def _convert_spark_date_format(fmt: str) -> str:
+    """Translate a Spark-style date format string to strftime-style."""
+    for spark_fmt, strftime_fmt in _SPARK_DATE_FORMAT_MAP:
+        fmt = fmt.replace(spark_fmt, strftime_fmt)
+    return fmt
+
+
+def try_to_date(col_name: Union[str, Column], fmt: Optional[str] = None) -> Column:
+    """
+    Mimics pyspark.sql.functions.try_to_date (Spark 4+).
+
+    Converts a string column to a date, returning null for unparseable values.
+
+    Args:
+        col_name (str or Column): Column with string values to convert to dates.
+        fmt (str, optional): The date format. Defaults to 'yyyy-MM-dd'.
+
+    Returns:
+        Column: A Column with values converted to Polars Date type (null for failures).
+    """
+    fmt = fmt or "yyyy-MM-dd"
+    strftime_fmt = _convert_spark_date_format(fmt)
+    expr = _to_expr(col_name) if isinstance(col_name, Column) else pl.col(col_name)
+    return Column(expr.str.strptime(pl.Date, strftime_fmt, strict=False))
+
+
+def try_element_at(col_name: Union[str, Column], extraction: Union[str, int, Column]) -> Column:
+    """
+    Mimics pyspark.sql.functions.try_element_at (Spark 4+).
+
+    For arrays: uses 1-based indexing (positive and negative). Returns null
+    for out-of-bounds access instead of raising.
+
+    For maps (materialized as List(Struct(key, value))): looks up the key and
+    returns null when absent.
+
+    Args:
+        col_name (str or Column): The array or map column.
+        extraction (str, int, or Column): The index (1-based int) for arrays,
+            or the key (str / Column) for maps.
+
+    Returns:
+        Column: A Column with the extracted element, or null on failure.
+    """
+    col_expr = _to_expr(col_name) if isinstance(col_name, Column) else pl.col(col_name)
+
+    if isinstance(extraction, Column):
+        extraction = extraction.to_native()
+
+    if isinstance(extraction, pl.Expr):
+        # Dynamic column-based key lookup for maps: list.eval pattern
+        return Column(
+            col_expr.list.eval(
+                pl.when(pl.element().struct.field("key") == extraction).then(pl.element().struct.field("value"))
+            )
+            .list.drop_nulls()
+            .list.first()
+        )
+
+    if isinstance(extraction, int):
+        # Spark uses 1-based indexing; index 0 is invalid -> null
+        if extraction == 0:
+            return Column(pl.lit(None))
+        polars_idx = extraction - 1 if extraction > 0 else extraction
+        return Column(col_expr.list.get(polars_idx, null_on_oob=True))
+
+    if isinstance(extraction, str):
+        # Map key lookup: List(Struct(key, value)) layout
+        return Column(
+            col_expr.list.eval(
+                pl.when(pl.element().struct.field("key") == pl.lit(extraction)).then(
+                    pl.element().struct.field("value")
+                )
+            )
+            .list.drop_nulls()
+            .list.first()
+        )
+
+    raise TypeError(f"try_element_at extraction must be int, str, or Column, got {type(extraction).__name__}")

--- a/sparkleframe/polarsdf/functions.py
+++ b/sparkleframe/polarsdf/functions.py
@@ -533,6 +533,20 @@ def lower(col_name: Union[str, Column]) -> Column:
     return Column(expr.str.to_lowercase())
 
 
+def _as_col_expr(col_name: Union[str, Column]) -> pl.Expr:
+    return _to_expr(col_name) if isinstance(col_name, Column) else pl.col(col_name)
+
+
+def concat(*cols: Union[str, Column]) -> Column:
+    """
+    Mimics pyspark.sql.functions.concat for string columns (null if any input is null).
+    """
+    if not cols:
+        raise ValueError("concat requires at least one column")
+    exprs = [_as_col_expr(c).cast(pl.String, strict=False) for c in cols]
+    return Column(pl.concat_str(exprs, separator="", ignore_nulls=False))
+
+
 def _struct_expand_varargs(cols: tuple[Any, ...]) -> tuple[Any, ...]:
     """Match PySpark ``struct`` when called as ``struct([c1, c2])`` or ``struct({...})``."""
     if len(cols) == 1 and isinstance(cols[0], (list, set)):

--- a/sparkleframe/polarsdf/functions.py
+++ b/sparkleframe/polarsdf/functions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from typing import Any, Optional, Union
+from uuid import uuid4
 
 import polars as pl
 
@@ -707,3 +708,22 @@ def try_element_at(col_name: Union[str, Column], extraction: Union[str, int, Col
         )
 
     raise TypeError(f"try_element_at extraction must be int, str, or Column, got {type(extraction).__name__}")
+
+
+def uuid() -> Column:
+    """
+    Mimics :func:`pyspark.sql.functions.uuid` (Spark 4.1+), unseeded form only.
+
+    One random canonical UUID string per row via :func:`uuid.uuid4` (not Spark’s JVM
+    output). ``uuid(seed=…)`` is not supported in sparkleframe.
+    """
+
+    def _row_uuid4(_: Any) -> str:
+        return str(uuid4())
+
+    return Column(
+        pl.int_range(0, pl.len(), dtype=pl.Int64, eager=False).map_elements(
+            _row_uuid4,
+            return_dtype=pl.String,
+        )
+    )

--- a/sparkleframe/polarsdf/functions_test.py
+++ b/sparkleframe/polarsdf/functions_test.py
@@ -1,4 +1,6 @@
 import json
+import re
+import uuid as std_uuid
 from datetime import date
 
 import pandas as pd
@@ -66,6 +68,7 @@ from sparkleframe.polarsdf.functions import (
     try_element_at,
     try_to_date,
     try_to_timestamp,
+    uuid,
     when,
 )
 from sparkleframe.tests.pyspark_test import assert_pyspark_df_equal
@@ -688,6 +691,21 @@ class TestConcat:
             spark_concat(spark_col("lane"), spark_lit("-"), spark_col("slot")).alias("merged"),
         )
         assert_pyspark_df_equal(result_spark_df, expected_df, ignore_nullable=True)
+
+
+_RE_UUID_V4 = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$")
+
+
+class TestUuid:
+    def test_uuid_yields_version4_string_format(self) -> None:
+        """``uuid()`` uses ``uuid4()``; unseeded values are not equal to PySpark, only shape is asserted."""
+        df = DataFrame(pl.DataFrame({"a": list(range(20))}))
+        out = df.select(uuid().alias("u")).to_native_df()["u"].to_list()
+        assert len(out) == 20
+        assert len(set(out)) == 20
+        for s in out:
+            assert _RE_UUID_V4.match(s) is not None
+            assert std_uuid.UUID(s).version == 4
 
 
 class TestTryToTimestamp:

--- a/sparkleframe/polarsdf/functions_test.py
+++ b/sparkleframe/polarsdf/functions_test.py
@@ -12,6 +12,7 @@ from pyspark.sql.functions import asc_nulls_first as spark_asc_nulls_first
 from pyspark.sql.functions import asc_nulls_last as spark_asc_nulls_last
 from pyspark.sql.functions import coalesce as spark_coalesce
 from pyspark.sql.functions import col as spark_col
+from pyspark.sql.functions import concat as spark_concat
 from pyspark.sql.functions import dense_rank as spark_dense_rank
 from pyspark.sql.functions import desc as spark_desc
 from pyspark.sql.functions import desc_nulls_first as spark_desc_nulls_first
@@ -47,6 +48,7 @@ from sparkleframe.polarsdf.functions import (
     asc_nulls_last,
     coalesce,
     col,
+    concat,
     dense_rank,
     desc,
     desc_nulls_first,
@@ -622,6 +624,70 @@ class TestFunctions:
     def test_struct_requires_at_least_one_column(self):
         with pytest.raises(ValueError, match="struct requires at least one column"):
             struct()
+
+
+class TestConcat:
+    """Behaviour tests for :func:`~sparkleframe.polarsdf.functions.concat` (not copied from prior commits)."""
+
+    def test_concat_without_inputs_raises(self) -> None:
+        with pytest.raises(ValueError, match="concat requires at least one column"):
+            concat()
+
+    def test_concat_single_column_is_identity_on_strings(self, spark) -> None:
+        data = {"token": ["zig", None, ""]}
+        pl_df = pl.DataFrame(data)
+        polars_df = DataFrame(pl_df)
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        out_schema = SparkStructType([SparkStructField("out", SparkStringType(), True)])
+        result_spark_df = create_spark_df(spark, polars_df.select(concat("token").alias("out")), schema=out_schema)
+        expected_df = spark_df.select(spark_concat(spark_col("token")).alias("out"))
+        assert_pyspark_df_equal(result_spark_df, expected_df, ignore_nullable=True)
+
+    def test_concat_two_parts_any_null_yields_null(self, spark) -> None:
+        data = {
+            "prefix": ["aa", None, "cc"],
+            "suffix": ["bb", "bb", None],
+        }
+        pl_df = pl.DataFrame(data)
+        polars_df = DataFrame(pl_df)
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        out_schema = SparkStructType([SparkStructField("out", SparkStringType(), True)])
+        result_spark_df = create_spark_df(
+            spark,
+            polars_df.select(concat(col("prefix"), col("suffix")).alias("out")),
+            schema=out_schema,
+        )
+        expected_df = spark_df.select(spark_concat(spark_col("prefix"), spark_col("suffix")).alias("out"))
+        assert_pyspark_df_equal(result_spark_df, expected_df, ignore_nullable=True)
+
+    def test_concat_accepts_string_name_or_column_object(self, spark) -> None:
+        pl_df = pl.DataFrame({"segment": ["north", "south"]})
+        polars_df = DataFrame(pl_df)
+        spark_df = spark.createDataFrame(pl_df.to_pandas())
+        by_name_spark = create_spark_df(
+            spark, polars_df.select(concat("segment", lit(":"), col("segment")).alias("out"))
+        )
+        by_col_spark = create_spark_df(
+            spark, polars_df.select(concat(col("segment"), lit(":"), "segment").alias("out"))
+        )
+        expected_df = spark_df.select(
+            spark_concat(spark_col("segment"), spark_lit(":"), spark_col("segment")).alias("out")
+        )
+        assert_pyspark_df_equal(by_name_spark, expected_df, ignore_nullable=True)
+        assert_pyspark_df_equal(by_col_spark, expected_df, ignore_nullable=True)
+
+    def test_concat_coerces_integer_columns_like_strings(self, spark) -> None:
+        pl_df = pl.DataFrame({"lane": [7, 0], "slot": [13, 42]})
+        polars_df = DataFrame(pl_df)
+        result_spark_df = create_spark_df(
+            spark,
+            polars_df.select(concat(col("lane"), lit("-"), col("slot")).alias("merged")),
+        )
+        spark_df = spark.createDataFrame(pl_df.to_pandas())
+        expected_df = spark_df.select(
+            spark_concat(spark_col("lane"), spark_lit("-"), spark_col("slot")).alias("merged"),
+        )
+        assert_pyspark_df_equal(result_spark_df, expected_df, ignore_nullable=True)
 
 
 class TestTryToTimestamp:

--- a/sparkleframe/polarsdf/functions_test.py
+++ b/sparkleframe/polarsdf/functions_test.py
@@ -4,6 +4,7 @@ import pandas as pd
 import pandas.testing as pdt
 import polars as pl
 import pytest
+from polars.testing import assert_frame_equal
 from pyspark.sql.functions import abs as spark_abs
 from pyspark.sql.functions import asc as spark_asc
 from pyspark.sql.functions import asc_nulls_first as spark_asc_nulls_first
@@ -22,9 +23,13 @@ from pyspark.sql.functions import rank as spark_rank
 from pyspark.sql.functions import regexp_replace as spark_regexp_replace
 from pyspark.sql.functions import round as spark_round
 from pyspark.sql.functions import row_number as spark_row_number
+from pyspark.sql.functions import struct as spark_struct
 from pyspark.sql.functions import to_timestamp as spark_to_timestamp
 from pyspark.sql.functions import when as spark_when
+from pyspark.sql.types import ArrayType as SparkArrayType
+from pyspark.sql.types import DoubleType as SparkDoubleType
 from pyspark.sql.types import IntegerType as SparkIntegerType
+from pyspark.sql.types import MapType as SparkMapType
 from pyspark.sql.types import StringType as SparkStringType
 from pyspark.sql.types import StructField as SparkStructField
 from pyspark.sql.types import StructType as SparkStructType
@@ -51,6 +56,7 @@ from sparkleframe.polarsdf.functions import (
     regexp_replace,
     round,
     row_number,
+    struct,
     to_timestamp,
     when,
 )
@@ -534,3 +540,79 @@ class TestFunctions:
         result_spark_df = create_spark_df(spark, result_df)
 
         assert_pyspark_df_equal(result_spark_df, expected_df, ignore_nullable=True)
+
+    def test_struct_oracle(self, spark, sparkle_df, spark_df):
+        """PySpark parity: field names follow CreateStruct (plain cols vs colN for lit / expr)."""
+        exprs = [
+            struct("a", "b").alias("s1"),
+            struct(col("a"), col("b")).alias("s2"),
+            struct([col("a"), col("b")]).alias("s3"),
+            struct(col("a"), lit(1)).alias("s4"),
+            struct(lit(1), lit(2)).alias("s5"),
+            struct(col("a") + 1, col("b")).alias("s6"),
+            struct(col("a"), struct(col("b"), lit(3))).alias("s7"),
+            struct(col("a").alias("z")).alias("s8"),
+        ]
+        expected_spark_df = spark_df.select(
+            spark_struct("a", "b").alias("s1"),
+            spark_struct(spark_col("a"), spark_col("b")).alias("s2"),
+            spark_struct([spark_col("a"), spark_col("b")]).alias("s3"),
+            spark_struct(spark_col("a"), spark_lit(1)).alias("s4"),
+            spark_struct(spark_lit(1), spark_lit(2)).alias("s5"),
+            spark_struct(spark_col("a") + 1, spark_col("b")).alias("s6"),
+            spark_struct(spark_col("a"), spark_struct(spark_col("b"), spark_lit(3))).alias("s7"),
+            spark_struct(spark_col("a").alias("z")).alias("s8"),
+        )
+        pdf = sparkle_df.select(*exprs).toPandas()
+        result_spark_df = spark.createDataFrame(pdf, schema=expected_spark_df.schema)
+        assert_pyspark_df_equal(result_spark_df, expected_spark_df, ignore_nullable=True)
+
+    def test_struct_nested_aliased_inner_structs_match_spark(self, spark, sparkle_df, spark_df):
+        """Outer struct must use .alias() names for nested struct children (not col1/col2)."""
+        inner_left = struct(col("a").alias("field_a"))
+        inner_right = struct(col("b").alias("field_b"))
+        composite = struct(inner_left.alias("nested_x"), inner_right.alias("nested_y"))
+        pdf = sparkle_df.select(composite.alias("composite")).toPandas()
+        expected_spark_df = spark_df.select(
+            spark_struct(
+                spark_struct(spark_col("a").alias("field_a")).alias("nested_x"),
+                spark_struct(spark_col("b").alias("field_b")).alias("nested_y"),
+            ).alias("composite")
+        )
+        result_spark_df = spark.createDataFrame(pdf, schema=expected_spark_df.schema)
+        assert_pyspark_df_equal(result_spark_df, expected_spark_df, ignore_nullable=True)
+
+    def test_struct_nested_with_array_and_map(self, spark):
+        """Parity with Spark struct(array, map); compare via Arrow (avoids pandas map/dict mismatch)."""
+        schema = SparkStructType(
+            [
+                SparkStructField("id", SparkIntegerType(), True),
+                SparkStructField("nums", SparkArrayType(SparkIntegerType()), True),
+                SparkStructField("kv", SparkMapType(SparkStringType(), SparkDoubleType()), True),
+            ]
+        )
+        spark_row = (1, [10, 20, 30], {"x": 1.0, "y": 2.0})
+        spark_input = spark.createDataFrame([spark_row], schema)
+        pl_df = pl.DataFrame(
+            {
+                "id": [1],
+                "nums": [[10, 20, 30]],
+                "kv": [[{"key": "x", "value": 1.0}, {"key": "y", "value": 2.0}]],
+            }
+        )
+        sparkle_df = DataFrame(pl_df)
+        exprs = [
+            struct(col("id"), col("nums"), col("kv")).alias("s1"),
+            struct(col("id"), struct(col("nums"), col("kv"))).alias("s2"),
+        ]
+        expected_spark_df = spark_input.select(
+            spark_struct(spark_col("id"), spark_col("nums"), spark_col("kv")).alias("s1"),
+            spark_struct(spark_col("id"), spark_struct(spark_col("nums"), spark_col("kv"))).alias("s2"),
+        )
+        got = sparkle_df.select(*exprs).to_native_df()
+        expected_pl = pl.from_arrow(expected_spark_df.toArrow())
+        assert_frame_equal(got, expected_pl, check_dtypes=False)
+
+    def test_struct_requires_at_least_one_column(self):
+        with pytest.raises(ValueError, match="struct requires at least one column"):
+            struct()

--- a/sparkleframe/polarsdf/functions_test.py
+++ b/sparkleframe/polarsdf/functions_test.py
@@ -1,4 +1,5 @@
 import json
+from datetime import date
 
 import pandas as pd
 import pandas.testing as pdt
@@ -25,6 +26,8 @@ from pyspark.sql.functions import round as spark_round
 from pyspark.sql.functions import row_number as spark_row_number
 from pyspark.sql.functions import struct as spark_struct
 from pyspark.sql.functions import to_timestamp as spark_to_timestamp
+from pyspark.sql.functions import try_element_at as spark_try_element_at
+from pyspark.sql.functions import try_to_timestamp as spark_try_to_timestamp
 from pyspark.sql.functions import when as spark_when
 from pyspark.sql.types import ArrayType as SparkArrayType
 from pyspark.sql.types import DoubleType as SparkDoubleType
@@ -58,6 +61,9 @@ from sparkleframe.polarsdf.functions import (
     row_number,
     struct,
     to_timestamp,
+    try_element_at,
+    try_to_date,
+    try_to_timestamp,
     when,
 )
 from sparkleframe.tests.pyspark_test import assert_pyspark_df_equal
@@ -616,3 +622,218 @@ class TestFunctions:
     def test_struct_requires_at_least_one_column(self):
         with pytest.raises(ValueError, match="struct requires at least one column"):
             struct()
+
+
+class TestTryToTimestamp:
+    """Tests for try_to_timestamp — verifies null-safe parsing behaviour."""
+
+    @pytest.mark.parametrize(
+        "datetime_strs, fmt",
+        [
+            (["2023-01-01 12:34:56", "2024-02-02 23:45:01"], "yyyy-MM-dd HH:mm:ss"),
+            (["01-03-2023 09:15:00", "31-12-2022 23:59:59"], "dd-MM-yyyy HH:mm:ss"),
+            (["2024-05-31 20:14:19.993", "2023-12-12 11:11:11.123"], "yyyy-MM-dd HH:mm:ss.SSS"),
+        ],
+    )
+    def test_try_to_timestamp_valid_matches_to_timestamp(self, spark, datetime_strs, fmt):
+        df = pd.DataFrame({"ts": datetime_strs})
+        polars_df = DataFrame(pl.DataFrame(df))
+
+        result_strict = polars_df.select(to_timestamp("ts", fmt).alias("result")).to_native_df()
+        result_try = polars_df.select(try_to_timestamp("ts", fmt).alias("result")).to_native_df()
+
+        assert result_strict["result"].to_list() == result_try["result"].to_list()
+
+        spark_df = spark.createDataFrame(df)
+        expected_df = spark_df.select(spark_try_to_timestamp(spark_col("ts"), spark_lit(fmt)).alias("result"))
+        result_spark_df = create_spark_df(spark, polars_df.select(try_to_timestamp("ts", fmt).alias("result")))
+        assert_pyspark_df_equal(result_spark_df, expected_df, ignore_nullable=True)
+
+    def test_try_to_timestamp_malformed_returns_null(self, spark):
+        df = pl.DataFrame({"ts": ["2023-01-01 12:34:56", "not-a-date", None]})
+        polars_df = DataFrame(df)
+        result = polars_df.select(try_to_timestamp("ts").alias("result")).to_native_df()
+
+        assert result["result"][0] is not None
+        assert result["result"][1] is None
+        assert result["result"][2] is None
+
+        spark_df = spark.createDataFrame(df.to_pandas())
+        expected_df = spark_df.select(
+            spark_try_to_timestamp(spark_col("ts"), spark_lit("yyyy-MM-dd HH:mm:ss")).alias("result")
+        )
+        result_spark_df = create_spark_df(spark, polars_df.select(try_to_timestamp("ts").alias("result")))
+        assert_pyspark_df_equal(result_spark_df, expected_df, ignore_nullable=True)
+
+    def test_try_to_timestamp_accepts_column_input(self, spark):
+        df = pl.DataFrame({"ts": ["2023-01-01 12:34:56"]})
+        polars_df = DataFrame(df)
+        result = polars_df.select(try_to_timestamp(col("ts")).alias("result")).to_native_df()
+
+        assert result["result"][0] is not None
+
+        spark_df = spark.createDataFrame(df.to_pandas())
+        expected_df = spark_df.select(
+            spark_try_to_timestamp(spark_col("ts"), spark_lit("yyyy-MM-dd HH:mm:ss")).alias("result")
+        )
+        result_spark_df = create_spark_df(spark, polars_df.select(try_to_timestamp(col("ts")).alias("result")))
+        assert_pyspark_df_equal(result_spark_df, expected_df, ignore_nullable=True)
+
+
+class TestTryToDate:
+    """Tests for try_to_date — verifies null-safe date parsing."""
+
+    def test_try_to_date_default_format(self, spark):
+        df = pl.DataFrame({"d": ["1997-02-28", "2024-12-31", "bad", None]})
+        polars_df = DataFrame(df)
+        result = polars_df.select(try_to_date("d").alias("result")).to_native_df()
+
+        assert result["result"][0] == date(1997, 2, 28)
+        assert result["result"][1] == date(2024, 12, 31)
+        assert result["result"][2] is None
+        assert result["result"][3] is None
+
+        expected_df = spark.createDataFrame(
+            [(date(1997, 2, 28),), (date(2024, 12, 31),), (None,), (None,)],
+            schema="result date",
+        )
+        result_spark_df = create_spark_df(spark, polars_df.select(try_to_date("d").alias("result")))
+        assert_pyspark_df_equal(result_spark_df, expected_df, ignore_nullable=True)
+
+    def test_try_to_date_custom_format(self, spark):
+        df = pl.DataFrame({"d": ["28-02-1997", "31-12-2024"]})
+        polars_df = DataFrame(df)
+        result = polars_df.select(try_to_date("d", "dd-MM-yyyy").alias("result")).to_native_df()
+
+        assert result["result"][0] == date(1997, 2, 28)
+        assert result["result"][1] == date(2024, 12, 31)
+
+        expected_df = spark.createDataFrame(
+            [(date(1997, 2, 28),), (date(2024, 12, 31),)],
+            schema="result date",
+        )
+        result_spark_df = create_spark_df(spark, polars_df.select(try_to_date("d", "dd-MM-yyyy").alias("result")))
+        assert_pyspark_df_equal(result_spark_df, expected_df, ignore_nullable=True)
+
+    def test_try_to_date_accepts_column_input(self, spark):
+        df = pl.DataFrame({"d": ["2024-01-01"]})
+        polars_df = DataFrame(df)
+        result = polars_df.select(try_to_date(col("d")).alias("result")).to_native_df()
+        assert result["result"][0] is not None
+
+        expected_df = spark.createDataFrame([(date(2024, 1, 1),)], schema="result date")
+        result_spark_df = create_spark_df(spark, polars_df.select(try_to_date(col("d")).alias("result")))
+        assert_pyspark_df_equal(result_spark_df, expected_df, ignore_nullable=True)
+
+
+class TestTryElementAt:
+    """Tests for try_element_at — arrays (1-based) and maps."""
+
+    @staticmethod
+    def _spark_df_string_array(spark, values: list):
+        return spark.createDataFrame(
+            [(values,)],
+            schema=SparkStructType([SparkStructField("arr", SparkArrayType(SparkStringType()), True)]),
+        )
+
+    @staticmethod
+    def _spark_df_from_polars_expr(spark, polars_df: DataFrame, expr, value_type):
+        pdf = polars_df.select(expr).to_native_df().to_pandas()
+        return spark.createDataFrame(pdf, schema=SparkStructType([SparkStructField("v", value_type, True)]))
+
+    def test_array_positive_index(self, spark):
+        df = pl.DataFrame({"arr": [["a", "b", "c"]]})
+        polars_df = DataFrame(df)
+        result = polars_df.select(try_element_at("arr", 1).alias("v")).to_native_df()
+        assert result["v"][0] == "a"
+        spark_df = self._spark_df_string_array(spark, ["a", "b", "c"])
+        expected = spark_df.select(spark_try_element_at(spark_col("arr"), spark_lit(1)).alias("v"))
+        result_spark_df = create_spark_df(spark, polars_df.select(try_element_at("arr", 1).alias("v")))
+        assert_pyspark_df_equal(result_spark_df, expected, ignore_nullable=True)
+
+    def test_array_last_element(self, spark):
+        df = pl.DataFrame({"arr": [["a", "b", "c"]]})
+        polars_df = DataFrame(df)
+        result = polars_df.select(try_element_at("arr", 3).alias("v")).to_native_df()
+        assert result["v"][0] == "c"
+        spark_df = self._spark_df_string_array(spark, ["a", "b", "c"])
+        expected = spark_df.select(spark_try_element_at(spark_col("arr"), spark_lit(3)).alias("v"))
+        result_spark_df = create_spark_df(spark, polars_df.select(try_element_at("arr", 3).alias("v")))
+        assert_pyspark_df_equal(result_spark_df, expected, ignore_nullable=True)
+
+    def test_array_negative_index(self, spark):
+        df = pl.DataFrame({"arr": [["a", "b", "c"]]})
+        polars_df = DataFrame(df)
+        result = polars_df.select(try_element_at("arr", -1).alias("v")).to_native_df()
+        assert result["v"][0] == "c"
+        spark_df = self._spark_df_string_array(spark, ["a", "b", "c"])
+        expected = spark_df.select(spark_try_element_at(spark_col("arr"), spark_lit(-1)).alias("v"))
+        result_spark_df = create_spark_df(spark, polars_df.select(try_element_at("arr", -1).alias("v")))
+        assert_pyspark_df_equal(result_spark_df, expected, ignore_nullable=True)
+
+    def test_array_oob_returns_null(self, spark):
+        df = pl.DataFrame({"arr": [["a", "b", "c"]]})
+        polars_df = DataFrame(df)
+        result = polars_df.select(try_element_at("arr", 4).alias("v")).to_native_df()
+        assert result["v"][0] is None
+        spark_df = self._spark_df_string_array(spark, ["a", "b", "c"])
+        expected = spark_df.select(spark_try_element_at(spark_col("arr"), spark_lit(4)).alias("v"))
+        null_string_schema = SparkStructType([SparkStructField("v", SparkStringType(), True)])
+        result_spark_df = create_spark_df(
+            spark,
+            polars_df.select(try_element_at("arr", 4).alias("v")),
+            schema=null_string_schema,
+        )
+        assert_pyspark_df_equal(result_spark_df, expected, ignore_nullable=True)
+
+    def test_array_zero_index_returns_null(self, spark):
+        df = pl.DataFrame({"arr": [["a", "b", "c"]]})
+        polars_df = DataFrame(df)
+        result = polars_df.select(try_element_at("arr", 0).alias("v")).to_native_df()
+        assert result["v"][0] is None
+        # Spark 4 try_element_at(col, 0) fails at runtime (invalid index); we return null instead.
+        result_spark_df = self._spark_df_from_polars_expr(
+            spark, polars_df, try_element_at("arr", 0).alias("v"), SparkStringType()
+        )
+        assert result_spark_df.collect()[0]["v"] is None
+
+    def test_map_key_present(self, spark):
+        df = pl.DataFrame({"m": [[{"key": "a", "value": 1.0}, {"key": "b", "value": 2.0}]]})
+        polars_df = DataFrame(df)
+        result = polars_df.select(try_element_at("m", "a").alias("v")).to_native_df()
+        assert result["v"][0] == 1.0
+        spark_df = spark.createDataFrame(
+            [({"a": 1.0, "b": 2.0},)],
+            schema=SparkStructType([SparkStructField("m", SparkMapType(SparkStringType(), SparkDoubleType()), True)]),
+        )
+        expected = spark_df.select(spark_try_element_at(spark_col("m"), spark_lit("a")).alias("v"))
+        result_spark_df = create_spark_df(spark, polars_df.select(try_element_at("m", "a").alias("v")))
+        assert_pyspark_df_equal(result_spark_df, expected, ignore_nullable=True)
+
+    def test_map_key_absent_returns_null(self, spark):
+        df = pl.DataFrame({"m": [[{"key": "a", "value": 1.0}, {"key": "b", "value": 2.0}]]})
+        polars_df = DataFrame(df)
+        result = polars_df.select(try_element_at("m", "c").alias("v")).to_native_df()
+        assert result["v"][0] is None
+        spark_df = spark.createDataFrame(
+            [({"a": 1.0, "b": 2.0},)],
+            schema=SparkStructType([SparkStructField("m", SparkMapType(SparkStringType(), SparkDoubleType()), True)]),
+        )
+        expected = spark_df.select(spark_try_element_at(spark_col("m"), spark_lit("c")).alias("v"))
+        null_double_schema = SparkStructType([SparkStructField("v", SparkDoubleType(), True)])
+        result_spark_df = create_spark_df(
+            spark,
+            polars_df.select(try_element_at("m", "c").alias("v")),
+            schema=null_double_schema,
+        )
+        assert_pyspark_df_equal(result_spark_df, expected, ignore_nullable=True)
+
+    def test_accepts_column_input(self, spark):
+        df = pl.DataFrame({"arr": [["x", "y"]]})
+        polars_df = DataFrame(df)
+        result = polars_df.select(try_element_at(col("arr"), 1).alias("v")).to_native_df()
+        assert result["v"][0] == "x"
+        spark_df = self._spark_df_string_array(spark, ["x", "y"])
+        expected = spark_df.select(spark_try_element_at(spark_col("arr"), spark_lit(1)).alias("v"))
+        result_spark_df = create_spark_df(spark, polars_df.select(try_element_at(col("arr"), 1).alias("v")))
+        assert_pyspark_df_equal(result_spark_df, expected, ignore_nullable=True)

--- a/sparkleframe/polarsdf/types.py
+++ b/sparkleframe/polarsdf/types.py
@@ -1,7 +1,33 @@
 import json
-from typing import Any, Union, Dict, Optional, List, Iterator
+from typing import Any, Dict, Iterator, List, Optional, Union
 
 import polars as pl
+
+SPARK_TYPE_NAME_MAP: dict[str, pl.DataType] = {
+    "string": pl.Utf8,
+    "int": pl.Int32,
+    "integer": pl.Int32,
+    "bigint": pl.Int64,
+    "long": pl.Int64,
+    "short": pl.Int16,
+    "smallint": pl.Int16,
+    "tinyint": pl.Int8,
+    "byte": pl.Int8,
+    "float": pl.Float32,
+    "double": pl.Float64,
+    "boolean": pl.Boolean,
+    "date": pl.Date,
+    "timestamp": pl.Datetime,
+    "binary": pl.Binary,
+}
+
+
+def spark_type_name_to_polars(name: str) -> pl.DataType:
+    key = name.strip().lower()
+    try:
+        return SPARK_TYPE_NAME_MAP[key]
+    except KeyError:
+        raise ValueError(f"Unsupported Spark type name for try_cast: '{name}'") from None
 
 
 class DataType:


### PR DESCRIPTION
## Summary

Adds Spark-aligned APIs on the Polars-backed layer: `struct`, `collect_list`, `uuid`, `DataFrame.drop`, and null-safe `try_to_*` helpers plus `Column.try_cast`. Refactors `to_timestamp` parsing in the last commit so `try_to_timestamp` can share the same path.

## Changes (by commit)

1. **`feat(functions): add struct`** — `struct()` with PySpark-style field naming; tests vs Spark.
2. **`feat(functions): add collect_list`** — `collect_list` for grouped aggregation; dataframe parity test.
3. **`feat(functions): add uuid()`** — `uuid()` - Introduced by pyspark v4.1.0
4. **`feat(dataframe): add drop`** — `DataFrame.drop` (names / `Column` / missing columns / no-arg copy).
5. **`feat(functions): add try_to_* functions; feat(column): add try_cast`** — `try_to_timestamp`, `try_to_date`, `try_element_at`; `Column.try_cast` with Spark type names; shared strict timestamp parsing refactor for `to_timestamp` / `try_to_timestamp`.

## Review notes

**Reviewing commit-by-commit is recommended** — each commit is scoped to one feature area, so the diff stays small and the intent stays clear.
