### PR TITLE
fix!: relax pandas and pyarrow version constraints in runtime dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,8 @@ dynamic = ["version", "description"]
 requires-python = ">=3.11"
 dependencies  = [
     "polars >= 1.39.3",
-    "pandas >= 3.0.2",
-    "pyarrow >= 23.0.1"
+    "pandas >= 2.2.3",
+    "pyarrow >= 19.0.1"
 ]
 
 [project.urls]


### PR DESCRIPTION
## What

Lower the runtime version constraints on `pandas` and `pyarrow` in `pyproject.toml` to minimal bounds that are known to work.

```diff
 dependencies  = [
     "polars >= 1.39.3",
-    "pandas >= 3.0.2",
-    "pyarrow >= 23.0.1"
+    "pandas >= 2.2.3",
+    "pyarrow >= 19.0.1"
 ]
```

## Why

The `pandas >= 3.0.2` and `pyarrow >= 23.0.1` constraints introduced in #90 cause a **breaking side-effect** when sparkleframe is installed as a transitive dependency inside environments that bundle older versions of these libraries.

**Concrete failure:** [flypipe](https://github.com/flypipe/flypipe) declares `sparkleframe >= 0.2`. When a Databricks job installs `flypipe==5.0.0` on **DBR 17.3** (PySpark 3.5 / pandas 2.x / older pyarrow), pip now resolves to `sparkleframe==0.7.0`, which forces `pandas >= 3.0.2` and `pyarrow >= 23.0.1`. This upgrades the runtime-bundled pandas 2.x to 3.x, and PySpark's internal `pyspark.pandas.groupby` fails at import time:

```
ImportError: cannot import name '_builtin_table' from 'pandas.core.common'
```

`pandas.core.common._builtin_table` was removed in pandas 3.0. The upgrade breaks **every** notebook task in the job (100+ tasks failed). The pyarrow pin triggers the same transitive-upgrade problem on runtimes that ship older pyarrow.

**Why the lower constraints are safe:** sparkleframe only uses basic APIs from both libraries — `pd.DataFrame` construction in `createDataFrame` and `.to_pandas()` via PyArrow in `show()`. These APIs are stable across the supported major versions, and the `pandas >= 2.2.3` / `pyarrow >= 19.0.1` combination has been validated without issues.

**After this fix:** pip can resolve to older (but still compatible) versions on runtimes like DBR 17.x, while Spark 4.x environments keep working with the newer pandas/pyarrow they ship.

> Note: `requirements-dev.txt` is intentionally not changed, so tests still run against `pandas==3.0.2` / `pyarrow==23.0.1`, preserving the CI pinning.