### PR TITLE
feat(polarsdf): functions parity, scalar type registry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,7 @@ error.
 | Timestamps | `to_timestamp` | `try_to_timestamp` |
 | Dates | `to_date` (where strict) | `try_to_date` |
 | Boolean from string | `cast` / strict helpers | `try_cast` / lenient helpers |
+| Array index / map lookup | `element_at` | `try_element_at` |
 
 When adding or changing behavior:
 
@@ -45,6 +46,12 @@ When adding or changing behavior:
 - Strict string→boolean casting uses `_string_to_bool_expr_strict`; lenient uses `_string_to_bool_expr` in
   `column_helpers.py`.
 - Do not reintroduce Spark 3–style silent nulls for strict APIs.
+- **Never implement a strict API as a one-line delegate to its `try_*` sibling** (e.g. `element_at` must not call
+  `try_element_at`). Spark 4 ANSI strictness is the default; the lenient function is the exception.
+- Shared logic belongs in `*_helpers.py` with a `strict` flag (see `element_at_column` in `functions_helpers.py`).
+- **`element_at` vs `try_element_at` string `extraction`:** for maps, Spark documents different semantics (SPARK-48766):
+  `element_at(col, "key")` uses the literal string `"key"`; `try_element_at(col, "key")` uses the column named `key`.
+  Use `lit("key")` (or a `Column` wrapping a literal) when a lenient map lookup needs a literal key.
 
 ## Testing requirements
 
@@ -86,6 +93,9 @@ What to assert depends on the API:
 2. **Lenient APIs** (`try_cast`, `try_to_timestamp`, `try_to_date`, …): include malformed rows; bad values become
    `null`, then compare the full result frame to Spark with `assert_sparkle_spark_frame_are_equal`.
 3. **Valid inputs:** still required — same pipeline on Spark and SparkleFrame, then frame parity.
+4. **Strict/lenient pairs:** add at least one test where Spark **raises** on the strict API (confirm on Spark first,
+   then `pytest.raises` on SparkleFrame evaluation), and a matching test that the lenient API returns `null` on the
+   same input. See `TestElementAt::test_array_oob_raises_like_spark` in `functions_test.py`.
 
 ```python
 import pytest

--- a/sparkleframe/polarsdf/column_helpers.py
+++ b/sparkleframe/polarsdf/column_helpers.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import contextvars
-import hashlib
 import re
 from contextlib import contextmanager
 from datetime import date, datetime, timezone
@@ -973,62 +972,3 @@ def _apply_getitem_key(expr: pl.Expr, key: Union[str, int]) -> pl.Expr:
 
         return expr.map_elements(_index_at, return_dtype=pl.Object)
     raise TypeError(f"getItem key must be str or int, got {type(key).__name__}")
-
-
-def _md5_sparklike(value: Any) -> str | None:
-    """MD5 digest as 32-char hex (Spark: UTF-8 for strings, raw bytes for binary)."""
-    if value is None:
-        return None
-    if isinstance(value, (bytes, bytearray, memoryview)):
-        b = bytes(value)
-    else:
-        b = str(value).encode("utf-8")
-    return hashlib.md5(b, usedforsecurity=False).hexdigest()
-
-
-def _re_split_sparklike(value: Any, pattern: str, limit: int) -> list[str] | None:
-    """Replicate PySpark ``split`` limit semantics; uses Python :mod:`re` (not the JVM)."""
-    if value is None:
-        return None
-    s = value if isinstance(value, str) else str(value)
-    if limit == 0 or limit < 0:
-        return re.split(pattern, s)
-    if limit == 1:
-        return [s]
-    return re.split(pattern, s, maxsplit=limit - 1)
-
-
-def _now_batch(s: pl.Series) -> pl.Series:
-    """Batch function producing a constant ``now()`` timestamp for all rows."""
-    if s.len() == 0:
-        return pl.Series("now", [], dtype=pl.Datetime("us"))
-    ts = datetime.now(timezone.utc).replace(tzinfo=None)
-    return pl.Series("now", [ts] * s.len(), dtype=pl.Datetime("us"))
-
-
-def _substring_sparklike(value: Any, pos: int, length: int) -> str | None:
-    """Replicate Spark substring semantics (1-based indexing; negative ``pos`` from end)."""
-    if value is None:
-        return None
-    if length <= 0:
-        return ""
-
-    s = value if isinstance(value, str) else str(value)
-    n = len(s)
-
-    if pos > 0:
-        start = pos - 1
-    elif pos < 0:
-        start = n + pos
-    else:
-        start = 0
-
-    if start < 0:
-        start = 0
-    if start >= n:
-        return ""
-
-    end = start + length
-    if end > n:
-        end = n
-    return s[start:end]

--- a/sparkleframe/polarsdf/column_helpers.py
+++ b/sparkleframe/polarsdf/column_helpers.py
@@ -1004,3 +1004,31 @@ def _now_batch(s: pl.Series) -> pl.Series:
         return pl.Series("now", [], dtype=pl.Datetime("us"))
     ts = datetime.now(timezone.utc).replace(tzinfo=None)
     return pl.Series("now", [ts] * s.len(), dtype=pl.Datetime("us"))
+
+
+def _substring_sparklike(value: Any, pos: int, length: int) -> str | None:
+    """Replicate Spark substring semantics (1-based indexing; negative ``pos`` from end)."""
+    if value is None:
+        return None
+    if length <= 0:
+        return ""
+
+    s = value if isinstance(value, str) else str(value)
+    n = len(s)
+
+    if pos > 0:
+        start = pos - 1
+    elif pos < 0:
+        start = n + pos
+    else:
+        start = 0
+
+    if start < 0:
+        start = 0
+    if start >= n:
+        return ""
+
+    end = start + length
+    if end > n:
+        end = n
+    return s[start:end]

--- a/sparkleframe/polarsdf/column_test.py
+++ b/sparkleframe/polarsdf/column_test.py
@@ -412,13 +412,7 @@ class TestColumnComparisonCoercion:
 
     def test_ordering_iso_datetime_string_vs_date_sub_offer_age(self) -> None:
         """``created >= date_sub(current_date(), 30)`` must be boolean, not null."""
-        import importlib
-
-        _fn = importlib.import_module("sparkleframe.polarsdf.functions")
-        if not hasattr(_fn, "current_date") or not hasattr(_fn, "date_sub"):
-            pytest.skip("requires current_date/date_sub (merged with functions PR in stack)")
-        current_date = _fn.current_date
-        date_sub = _fn.date_sub
+        from sparkleframe.polarsdf.functions import current_date, date_sub
 
         today = date.today()
         recent = pl.DataFrame({"created": [f"{today.isoformat()}T12:00:00Z"]})

--- a/sparkleframe/polarsdf/dataframe_helpers.py
+++ b/sparkleframe/polarsdf/dataframe_helpers.py
@@ -9,21 +9,12 @@ import polars as pl
 
 from sparkleframe.polarsdf import types as sft
 from sparkleframe.polarsdf.types import (
-    BinaryType,
-    BooleanType,
-    ByteType,
     DataType,
-    DateType,
     DecimalType,
-    DoubleType,
-    FloatType,
-    IntegerType,
-    LongType,
-    ShortType,
-    StringType,
     StructField,
     StructType,
-    TimestampType,
+    polars_dtype_to_spark_datatype,
+    polars_dtype_to_spark_sql_name,
 )
 from sparkleframe.polarsdf.types_utils import _MapTypeUtils
 
@@ -186,65 +177,10 @@ def coalesce_outer_join_keys(
 # Schema / dtypes helpers
 # ---------------------------------------------------------------------------
 
-POLARS_TO_PYSPARK_DTYPE_MAP = {
-    pl.Int8: "tinyint",
-    pl.Int16: "smallint",
-    pl.Int32: "int",
-    pl.Int64: "bigint",
-    pl.UInt8: "tinyint",
-    pl.UInt16: "smallint",
-    pl.UInt32: "int",
-    pl.UInt64: "bigint",
-    pl.Float32: "float",
-    pl.Float64: "double",
-    pl.Boolean: "boolean",
-    pl.Utf8: "string",
-    pl.Date: "date",
-    pl.Datetime: "timestamp",
-    pl.Time: "time",
-    pl.Duration: "interval",
-    pl.Object: "binary",
-    pl.List: "array",
-    pl.Struct: "struct",
-    pl.Decimal: "decimal",
-    pl.Binary: "binary",
-}
-
 
 def map_polars_dtype_to_spark_name(dtype: pl.DataType) -> str:
     """Map a Polars dtype to PySpark-style string name (for ``DataFrame.dtypes``)."""
-    if isinstance(dtype, pl.Decimal):
-        return f"decimal({dtype.precision},{dtype.scale})"
-
-    if isinstance(dtype, pl.Struct):
-        fields_str = ",".join(f"{field.name}:{map_polars_dtype_to_spark_name(field.dtype)}" for field in dtype.fields)
-        return f"struct<{fields_str}>"
-
-    for polars_type, spark_type in POLARS_TO_PYSPARK_DTYPE_MAP.items():
-        if isinstance(dtype, polars_type):
-            return spark_type
-
-    return str(dtype)
-
-
-POLARS_TO_SPARK_SCALARS = {
-    pl.Null: StringType(),
-    pl.Utf8: StringType(),
-    pl.Int32: IntegerType(),
-    pl.UInt32: IntegerType(),
-    pl.Int64: LongType(),
-    pl.UInt64: LongType(),
-    pl.Float32: FloatType(),
-    pl.Float64: DoubleType(),
-    pl.Boolean: BooleanType(),
-    pl.Date: DateType(),
-    pl.Datetime: TimestampType(),
-    pl.Int8: ByteType(),
-    pl.UInt8: ByteType(),
-    pl.Int16: ShortType(),
-    pl.UInt16: ShortType(),
-    pl.Binary: BinaryType(),
-}
+    return polars_dtype_to_spark_sql_name(dtype)
 
 
 def _declared_type_for(
@@ -295,11 +231,7 @@ def to_spark_datatype(
                 contains_null = decl.containsNull
         return sft.ArrayType(elem_dtype, containsNull=contains_null)
 
-    for pl_type, spark_type in POLARS_TO_SPARK_SCALARS.items():
-        if isinstance(dtype, pl_type):
-            return spark_type
-
-    raise TypeError(f"Unsupported dtype '{dtype}'")
+    return polars_dtype_to_spark_datatype(dtype)
 
 
 def polars_dtype_to_spark_structfield(

--- a/sparkleframe/polarsdf/dataframe_test.py
+++ b/sparkleframe/polarsdf/dataframe_test.py
@@ -211,6 +211,13 @@ class TestDataFrame:
         assert sf_result.count() == 0 == spark_result.count()
         assert_sparkle_spark_frame_are_equal(sf_result, spark_result)
 
+    def test_with_column_null_lit_empty_rows_matches_spark(self, spark) -> None:
+        empty_sparkle = DataFrame(pl.DataFrame({"id": pl.Series("id", [], dtype=pl.Int64)}))
+        empty_spark = spark.createDataFrame([], schema=SparkStructType([SparkStructField("id", SparkLongType())]))
+        sf_result = empty_sparkle.withColumn("n", PF.lit(None))
+        spark_result = empty_spark.withColumn("n", F.lit(None).cast("string"))
+        assert_sparkle_spark_frame_are_equal(sf_result, spark_result)
+
     def test_with_column_add(self, spark, sparkle_df, spark_df):
         result_spark_df = spark.createDataFrame(
             sparkle_df.withColumn("bonus", (PF.col("salary") * 0.1)).toPandas()
@@ -616,6 +623,43 @@ class TestDataFrame:
 
         result_spark_df = spark.createDataFrame(result_df.toPandas())
         assert_pyspark_df_equal(result_spark_df.orderBy("group"), expected_df.orderBy("group"), ignore_nullable=True)
+
+    @pytest.mark.parametrize("use_alias", [False, True])
+    def test_groupby_collect_set(self, spark, use_alias) -> None:
+        """collect_set matches Spark; sort_array makes order comparable (sets are unordered)."""
+        from sparkleframe.tests.utils import assert_sparkle_spark_frame_are_equal
+
+        data = {
+            "group": ["A", "A", "A", "B", "B"],
+            "value": [3, None, 1, 2, None],
+        }
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys())).orderBy(
+            "group", F.asc_nulls_last("value")
+        )
+        pl_df = DataFrame(pl.DataFrame(data)).sort("group", PF.asc_nulls_last("value"))
+
+        if not use_alias:
+            expected_df = spark_df.groupBy("group")
+            result_df = pl_df.groupBy("group")
+        else:
+            expected_df = spark_df.groupby("group")
+            result_df = pl_df.groupby("group")
+
+        expected_df = expected_df.agg(F.collect_set("value").alias("agg_result"))
+        result_df = result_df.agg(PF.collect_set("value").alias("agg_result"))
+
+        spark_sorted = expected_df.select(
+            F.col("group"),
+            F.sort_array(F.col("agg_result")).alias("agg_result"),
+        ).orderBy("group")
+        native = result_df.to_native_df()
+        sf_sorted = DataFrame(
+            native.select(
+                pl.col("group"),
+                pl.col("agg_result").list.sort().alias("agg_result"),
+            ).sort("group")
+        )
+        assert_sparkle_spark_frame_are_equal(sf_sorted, spark_sorted)
 
     def test_groupby_collect_list_nested_aliased_struct(self, spark):
         """collect_list(struct(...)) preserves aliased nested struct field names (not col1/col2)."""

--- a/sparkleframe/polarsdf/functions.py
+++ b/sparkleframe/polarsdf/functions.py
@@ -1,14 +1,26 @@
 from __future__ import annotations
 
-from typing import Any, Optional, Union
+import json
+from datetime import date
+from typing import Any, Callable, Optional, Union
 from uuid import uuid4
 
 import polars as pl
 
 from sparkleframe.polarsdf import WindowSpec
 from sparkleframe.polarsdf.column import Column, _to_expr
-from sparkleframe.polarsdf.column_helpers import _md5_sparklike, _now_batch, _re_split_sparklike
-from sparkleframe.polarsdf.functions_helpers import _RankWrapper, _to_datetime_column, _to_timestamp_no_format_column
+from sparkleframe.polarsdf.column_helpers import _md5_sparklike, _now_batch, _re_split_sparklike, _substring_sparklike
+from sparkleframe.polarsdf.functions_helpers import (
+    _as_date_sparklike_expr,
+    _coerce_json_value,
+    _RankWrapper,
+    _schema_from_string,
+    _to_date_column,
+    _to_datetime_column,
+    _to_timestamp_no_format_column,
+    element_at_column,
+)
+from sparkleframe.polarsdf.types import DataType
 
 
 def col(name: str) -> Column:
@@ -24,10 +36,12 @@ def col(name: str) -> Column:
     """
     if "." in name:
         parts = name.split(".")
-        expr = pl.col(parts[0])
+        # Defer struct navigation through Column so _apply_getitem_key runs under the
+        # active frame schema (null-safe / missing-field parity with Spark).
+        c: Column = Column(parts[0])
         for seg in parts[1:]:
-            expr = expr.struct.field(seg)
-        return Column(expr)  # pass a Polars Expr directly
+            c = c.getItem(seg)
+        return c
     return Column(pl.col(name))
 
 
@@ -48,6 +62,36 @@ def get_json_object(col: Union[str, Column], path: str) -> Column:
     col_expr = col.to_native() if isinstance(col, Column) else pl.col(col)
 
     return Column(col_expr.str.json_path_match(path))
+
+
+def from_json(col_name: Union[str, Column], schema: Union[DataType, str]) -> Column:
+    """
+    Mimics pyspark.sql.functions.from_json for common schemas.
+
+    Supports sparkleframe DataType schemas (ArrayType/MapType/StructType and primitives)
+    and simple Spark SQL schema strings (e.g. "array<string>", "map<string,string>",
+    "field_a STRING, field_b INT").
+    """
+    parsed_schema = _schema_from_string(schema) if isinstance(schema, str) else schema
+    expr = _to_expr(col_name) if isinstance(col_name, Column) else pl.col(col_name)
+
+    def _parse(value: Any) -> Any:
+        if value is None:
+            return None
+        if isinstance(value, (dict, list)):
+            raw = value
+        else:
+            try:
+                raw = json.loads(value)
+            except Exception:
+                return None
+        return _coerce_json_value(raw, parsed_schema)
+
+    if isinstance(parsed_schema, DataType):
+        return_dtype = parsed_schema.to_native()
+    else:
+        return_dtype = parsed_schema
+    return Column(expr.map_elements(_parse, return_dtype=return_dtype))
 
 
 def lit(value) -> Column:
@@ -174,6 +218,52 @@ def max(col_name: Union[str, Column]) -> Column:
     return Column(expr.max())
 
 
+def first(col_name: Union[str, Column], ignorenulls: bool = False) -> Column:
+    """Mimics pyspark.sql.functions.first."""
+    expr = _to_expr(col_name) if isinstance(col_name, Column) else pl.col(col_name)
+    return Column(expr.drop_nulls().first() if ignorenulls else expr.first())
+
+
+def map_from_entries(col_name: Union[str, Column]) -> Column:
+    """
+    Mimics pyspark.sql.functions.map_from_entries.
+
+    Expects an array of structs with ``key`` and ``value`` fields.
+    """
+    expr = _to_expr(col_name) if isinstance(col_name, Column) else pl.col(col_name)
+
+    def _entries_to_map(value: Any) -> Any:
+        if value is None:
+            return None
+        if isinstance(value, dict):
+            return value
+        if isinstance(value, list):
+            out: dict[Any, Any] = {}
+            for entry in value:
+                if isinstance(entry, dict) and "key" in entry and "value" in entry:
+                    out[entry["key"]] = entry["value"]
+            return out
+        return None
+
+    return Column(expr.map_elements(_entries_to_map, return_dtype=pl.Object))
+
+
+def map_keys(col_name: Union[str, Column]) -> Column:
+    """Mimics pyspark.sql.functions.map_keys."""
+    expr = _to_expr(col_name) if isinstance(col_name, Column) else pl.col(col_name)
+
+    def _keys(value: Any) -> Any:
+        if value is None:
+            return None
+        if isinstance(value, dict):
+            return list(value.keys())
+        if isinstance(value, list):
+            return [entry.get("key") for entry in value if isinstance(entry, dict) and "key" in entry]
+        return None
+
+    return Column(expr.map_elements(_keys, return_dtype=pl.List(pl.String)))
+
+
 def collect_list(col_name: Union[str, Column]) -> Column:
     """
     Mimics pyspark.sql.functions.collect_list.
@@ -189,6 +279,30 @@ def collect_list(col_name: Union[str, Column]) -> Column:
     """
     expr = _to_expr(col_name) if isinstance(col_name, Column) else pl.col(col_name)
     return Column(expr.filter(expr.is_not_null()).implode())
+
+
+def collect_set(col_name: Union[str, Column]) -> Column:
+    """
+    Mimics pyspark.sql.functions.collect_set.
+
+    Collects distinct non-null values per group when used with ``groupBy`` / ``agg``.
+    The order of elements in the result array is not guaranteed, matching PySpark.
+    """
+    expr = _to_expr(col_name) if isinstance(col_name, Column) else pl.col(col_name)
+    return Column(expr.filter(expr.is_not_null()).implode().list.unique())
+
+
+def transform(col_name: Union[str, Column], func: Callable[[Column], Any]) -> Column:
+    """
+    Mimics pyspark.sql.functions.transform for array columns.
+
+    Applies a lambda expression to each element of an array and returns a new array.
+    """
+    expr = _to_expr(col_name) if isinstance(col_name, Column) else pl.col(col_name)
+    element_col = Column(pl.element())
+    transformed = func(element_col)
+    transformed_expr = transformed.to_native() if isinstance(transformed, Column) else _to_expr(transformed)
+    return Column(expr.list.eval(transformed_expr))
 
 
 def round(col_name: Union[str, Column], scale: int = 0) -> Column:
@@ -551,6 +665,21 @@ def split(col_name: Union[str, Column], pattern: str, limit: int = -1) -> Column
     return Column(expr.map_elements(_one, return_dtype=pl.List(pl.String)))
 
 
+def substring(col_name: Union[str, Column], pos: int, length: int) -> Column:
+    """
+    Mimics pyspark.sql.functions.substring.
+
+    ``pos`` is 1-based (negative values count from string end).
+    """
+    expr = _to_expr(col_name) if isinstance(col_name, Column) else pl.col(col_name)
+    p, ln = pos, length
+
+    def _one(v: Any) -> str | None:
+        return _substring_sparklike(v, p, ln)
+
+    return Column(expr.map_elements(_one, return_dtype=pl.String))
+
+
 def now() -> Column:
     """
     Mimics pyspark.sql.functions.now: current timestamp (same value for all rows) at evaluation.
@@ -573,6 +702,90 @@ def monotonically_increasing_id() -> Column:
     partition id; multi-executor layout is not modeled.
     """
     return Column(pl.int_range(0, pl.len(), dtype=pl.Int64, eager=False))
+
+
+def current_date() -> Column:
+    """Mimics pyspark.sql.functions.current_date."""
+    return Column(pl.lit(date.today()))
+
+
+def date_sub(col_name: Union[str, Column], days: int) -> Column:
+    """
+    Mimics pyspark.sql.functions.date_sub.
+
+    String arguments use the same Spark-like string-to-date rules as :func:`datediff`.
+    """
+    expr = _to_expr(col_name) if isinstance(col_name, Column) else pl.col(col_name)
+    return Column(_as_date_sparklike_expr(expr) - pl.duration(days=int(days)))
+
+
+def datediff(end: Union[str, Column], start: Union[str, Column]) -> Column:
+    """
+    Mimics pyspark.sql.functions.datediff.
+
+    String end/start values are coerced to dates using rules closer to Spark ``cast(… as date)``.
+    """
+    end_expr = _to_expr(end) if isinstance(end, Column) else pl.col(end)
+    start_expr = _to_expr(start) if isinstance(start, Column) else pl.col(start)
+    e = _as_date_sparklike_expr(end_expr)
+    s = _as_date_sparklike_expr(start_expr)
+    return Column((e - s).dt.total_days().cast(pl.Int32))
+
+
+def months_between(end: Union[str, Column], start: Union[str, Column]) -> Column:
+    """
+    Mimics pyspark.sql.functions.months_between.
+
+    Uses a simplified Spark-like approximation for fractional months.
+    """
+    end_expr = _to_expr(end) if isinstance(end, Column) else pl.col(end)
+    start_expr = _to_expr(start) if isinstance(start, Column) else pl.col(start)
+    end_date = _as_date_sparklike_expr(end_expr)
+    start_date = _as_date_sparklike_expr(start_expr)
+    whole_months = (end_date.dt.year() - start_date.dt.year()) * 12 + (end_date.dt.month() - start_date.dt.month())
+    day_fraction = (end_date.dt.day() - start_date.dt.day()) / pl.lit(31.0)
+    return Column((whole_months + day_fraction).cast(pl.Float64))
+
+
+def broadcast(df: Any) -> Any:
+    """
+    Mimics pyspark.sql.functions.broadcast.
+
+    Sparkleframe runs in-process and has no join planner hints, so this is a no-op.
+    """
+    return df
+
+
+def array_contains(col_name: Union[str, Column], value: Union[str, Column, Any]) -> Column:
+    """Mimics pyspark.sql.functions.array_contains."""
+    array_expr = _to_expr(col_name) if isinstance(col_name, Column) else pl.col(col_name)
+    value_expr = _to_expr(value) if isinstance(value, Column) else pl.lit(value)
+    return Column(array_expr.list.contains(value_expr))
+
+
+def size(col_name: Union[str, Column]) -> Column:
+    """Mimics pyspark.sql.functions.size for array/map-like values."""
+    expr = _to_expr(col_name) if isinstance(col_name, Column) else pl.col(col_name)
+    return Column(pl.when(expr.is_null()).then(pl.lit(None)).otherwise(expr.list.len()).cast(pl.Int32))
+
+
+def filter(col_name: Union[str, Column], func: Callable[[Column], Any]) -> Column:
+    """Mimics pyspark.sql.functions.filter for array columns."""
+    expr = _to_expr(col_name) if isinstance(col_name, Column) else pl.col(col_name)
+    element_col = Column(pl.element())
+    predicate = func(element_col)
+    predicate_expr = predicate.to_native() if isinstance(predicate, Column) else _to_expr(predicate)
+    return Column(expr.list.eval(pl.when(predicate_expr).then(pl.element()).otherwise(pl.lit(None))).list.drop_nulls())
+
+
+def explode(col_name: Union[str, Column]) -> Column:
+    """Mimics pyspark.sql.functions.explode."""
+    expr = _to_expr(col_name) if isinstance(col_name, Column) else pl.col(col_name)
+    column = Column(expr.explode())
+    setattr(column, "_is_explode", True)
+    if isinstance(col_name, str):
+        setattr(column, "_explode_source_name", col_name)
+    return column
 
 
 def _as_col_expr(col_name: Union[str, Column]) -> pl.Expr:
@@ -680,18 +893,22 @@ def try_to_timestamp(
     return _to_datetime_column(col_name, fmt, strict=False)
 
 
-_SPARK_DATE_FORMAT_MAP = [
-    ("yyyy", "%Y"),
-    ("MM", "%m"),
-    ("dd", "%d"),
-]
+def to_date(col_name: Union[str, Column], fmt: Optional[str] = None) -> Column:
+    """
+    Mimics pyspark.sql.functions.to_date.
 
+    Converts a string column to a date using the given Spark format pattern.
+    Malformed values raise under Spark 4 ANSI defaults (see :func:`try_to_date`).
 
-def _convert_spark_date_format(fmt: str) -> str:
-    """Translate a Spark-style date format string to strftime-style."""
-    for spark_fmt, strftime_fmt in _SPARK_DATE_FORMAT_MAP:
-        fmt = fmt.replace(spark_fmt, strftime_fmt)
-    return fmt
+    Args:
+        col_name (str or Column): Column with string values to convert to dates.
+        fmt (str, optional): The date format. Defaults to ``yyyy-MM-dd``.
+
+    Returns:
+        Column: A Column with values converted to Polars Date type.
+    """
+    fmt = fmt or "yyyy-MM-dd"
+    return _to_date_column(col_name, fmt, strict=True)
 
 
 def try_to_date(col_name: Union[str, Column], fmt: Optional[str] = None) -> Column:
@@ -708,11 +925,7 @@ def try_to_date(col_name: Union[str, Column], fmt: Optional[str] = None) -> Colu
         Column: A Column with values converted to Polars Date type (null for failures).
     """
     fmt = fmt or "yyyy-MM-dd"
-    strftime_fmt = _convert_spark_date_format(fmt)
-    expr = _to_expr(col_name) if isinstance(col_name, Column) else pl.col(col_name)
-    # Spark applies the format to string inputs only; unparseable strings become null.
-    parsed = expr.cast(pl.String, strict=False).str.strptime(pl.Date, strftime_fmt, strict=False)
-    return Column(parsed)
+    return _to_date_column(col_name, fmt, strict=False)
 
 
 def try_element_at(col_name: Union[str, Column], extraction: Union[str, int, Column]) -> Column:
@@ -723,51 +936,31 @@ def try_element_at(col_name: Union[str, Column], extraction: Union[str, int, Col
     for out-of-bounds access instead of raising.
 
     For maps (materialized as List(Struct(key, value))): looks up the key and
-    returns null when absent.
+    returns null when absent. A string ``extraction`` is interpreted as a **column
+    name** (Spark SPARK-48766), not a literal key; use :func:`lit` wrapped in
+    :class:`~sparkleframe.polarsdf.column.Column` for a literal map key.
 
     Args:
         col_name (str or Column): The array or map column.
         extraction (str, int, or Column): The index (1-based int) for arrays,
-            or the key (str / Column) for maps.
+            or the key column name (str) / key expression (Column) for maps.
 
     Returns:
         Column: A Column with the extracted element, or null on failure.
     """
-    col_expr = _to_expr(col_name) if isinstance(col_name, Column) else pl.col(col_name)
+    return element_at_column(col_name, extraction, strict=False)
 
-    if isinstance(extraction, Column):
-        extraction = extraction.to_native()
 
-    if isinstance(extraction, pl.Expr):
-        # Dynamic column-based key lookup for maps: list.eval pattern
-        return Column(
-            col_expr.list.eval(
-                pl.when(pl.element().struct.field("key") == extraction).then(pl.element().struct.field("value"))
-            )
-            .list.drop_nulls()
-            .list.first()
-        )
+def element_at(col_name: Union[str, Column], extraction: Union[str, int, Column]) -> Column:
+    """
+    Mimics pyspark.sql.functions.element_at.
 
-    if isinstance(extraction, int):
-        # Spark uses 1-based indexing; index 0 is invalid -> null
-        if extraction == 0:
-            return Column(pl.lit(None))
-        polars_idx = extraction - 1 if extraction > 0 else extraction
-        return Column(col_expr.list.get(polars_idx, null_on_oob=True))
-
-    if isinstance(extraction, str):
-        # Map key lookup: List(Struct(key, value)) layout
-        return Column(
-            col_expr.list.eval(
-                pl.when(pl.element().struct.field("key") == pl.lit(extraction)).then(
-                    pl.element().struct.field("value")
-                )
-            )
-            .list.drop_nulls()
-            .list.first()
-        )
-
-    raise TypeError(f"try_element_at extraction must be int, str, or Column, got {type(extraction).__name__}")
+    Spark 4 with ANSI enabled: invalid array indices raise
+    ``SparkArrayIndexOutOfBoundsException``; use :func:`try_element_at` for null
+    on failure. A string ``extraction`` on a map is a **literal key** (unlike
+    :func:`try_element_at`, which treats a string as a column name).
+    """
+    return element_at_column(col_name, extraction, strict=True)
 
 
 def uuid() -> Column:

--- a/sparkleframe/polarsdf/functions.py
+++ b/sparkleframe/polarsdf/functions.py
@@ -9,12 +9,15 @@ import polars as pl
 
 from sparkleframe.polarsdf import WindowSpec
 from sparkleframe.polarsdf.column import Column, _to_expr
-from sparkleframe.polarsdf.column_helpers import _md5_sparklike, _now_batch, _re_split_sparklike, _substring_sparklike
 from sparkleframe.polarsdf.functions_helpers import (
     _as_date_sparklike_expr,
     _coerce_json_value,
+    _md5_sparklike,
+    _now_batch,
     _RankWrapper,
+    _re_split_sparklike,
     _schema_from_string,
+    _substring_sparklike,
     _to_date_column,
     _to_datetime_column,
     _to_timestamp_no_format_column,

--- a/sparkleframe/polarsdf/functions_helpers.py
+++ b/sparkleframe/polarsdf/functions_helpers.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import hashlib
+import re
+from datetime import datetime, timezone
 from typing import Any, Optional, Union
 
 import polars as pl
@@ -417,6 +420,65 @@ def element_at_column(
         return Column(_map_key_lookup_expr(col_expr, key_expr))
 
     raise TypeError(f"element_at extraction must be int, str, or Column, got {type(extraction).__name__}")
+
+
+def _md5_sparklike(value: Any) -> str | None:
+    """MD5 digest as 32-char hex (Spark: UTF-8 for strings, raw bytes for binary)."""
+    if value is None:
+        return None
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        b = bytes(value)
+    else:
+        b = str(value).encode("utf-8")
+    return hashlib.md5(b, usedforsecurity=False).hexdigest()
+
+
+def _re_split_sparklike(value: Any, pattern: str, limit: int) -> list[str] | None:
+    """Replicate PySpark ``split`` limit semantics; uses Python :mod:`re` (not the JVM)."""
+    if value is None:
+        return None
+    s = value if isinstance(value, str) else str(value)
+    if limit == 0 or limit < 0:
+        return re.split(pattern, s)
+    if limit == 1:
+        return [s]
+    return re.split(pattern, s, maxsplit=limit - 1)
+
+
+def _now_batch(s: pl.Series) -> pl.Series:
+    """Batch function producing a constant ``now()`` timestamp for all rows."""
+    if s.len() == 0:
+        return pl.Series("now", [], dtype=pl.Datetime("us"))
+    ts = datetime.now(timezone.utc).replace(tzinfo=None)
+    return pl.Series("now", [ts] * s.len(), dtype=pl.Datetime("us"))
+
+
+def _substring_sparklike(value: Any, pos: int, length: int) -> str | None:
+    """Replicate Spark substring semantics (1-based indexing; negative ``pos`` from end)."""
+    if value is None:
+        return None
+    if length <= 0:
+        return ""
+
+    s = value if isinstance(value, str) else str(value)
+    n = len(s)
+
+    if pos > 0:
+        start = pos - 1
+    elif pos < 0:
+        start = n + pos
+    else:
+        start = 0
+
+    if start < 0:
+        start = 0
+    if start >= n:
+        return ""
+
+    end = start + length
+    if end > n:
+        end = n
+    return s[start:end]
 
 
 class _RankWrapper(Column):

--- a/sparkleframe/polarsdf/functions_helpers.py
+++ b/sparkleframe/polarsdf/functions_helpers.py
@@ -1,12 +1,78 @@
 from __future__ import annotations
 
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 import polars as pl
 
 from sparkleframe.polarsdf.column import Column, _to_expr
-from sparkleframe.polarsdf.types import TimestampType
+from sparkleframe.polarsdf.types import (
+    ArrayType,
+    BooleanType,
+    ByteType,
+    DataType,
+    DecimalType,
+    DoubleType,
+    FloatType,
+    IntegerType,
+    LongType,
+    MapType,
+    ShortType,
+    StringType,
+    StructType,
+    TimestampType,
+    spark_name_to_datatype,
+    spark_type_name_to_polars,
+)
 from sparkleframe.polarsdf.window import WindowSpec
+
+_SPARK_DATE_FORMAT_MAP = [
+    ("yyyy", "%Y"),
+    ("MM", "%m"),
+    ("dd", "%d"),
+]
+
+
+def _convert_spark_date_format(fmt: str) -> str:
+    """Translate a Spark-style date format string to strftime-style."""
+    for spark_fmt, strftime_fmt in _SPARK_DATE_FORMAT_MAP:
+        fmt = fmt.replace(spark_fmt, strftime_fmt)
+    return fmt
+
+
+def _assert_no_unparsed_dates(s: pl.Series) -> pl.Series:
+    """Raise when a non-null input produced a null date (Spark CAST_INVALID_INPUT)."""
+    df = s.struct.unnest()
+    inp = df.get_column("_input")
+    res = df.get_column("_result")
+    mask = inp.is_not_null() & res.is_null()
+    if mask.any():
+        bad = inp.filter(mask)[0]
+        raise pl.exceptions.InvalidOperationError(
+            f"[CAST_INVALID_INPUT] The value '{bad}' of the type \"STRING\" cannot be cast to "
+            f'"DATE" because it is malformed. Use `try_to_date` to tolerate malformed '
+            f"input and return NULL instead."
+        )
+    return res
+
+
+def _to_date_column(col_name: Union[str, Column], fmt: str, *, strict: bool = True) -> Column:
+    """
+    Parse strings to :class:`Date` using a Spark format string (``yyyy-MM-dd`` style).
+
+    ``to_date`` passes ``strict=True``; ``try_to_date`` passes ``strict=False``. When
+    strict, non-null inputs that do not match the pattern raise (Spark 4 ANSI default).
+    """
+    strftime_fmt = _convert_spark_date_format(fmt)
+    input_expr = pl.col(col_name) if isinstance(col_name, str) else _to_expr(col_name)
+    string_expr = input_expr.cast(pl.String, strict=False)
+    parsed = string_expr.str.strptime(pl.Date, strftime_fmt, strict=strict)
+    if strict:
+        parsed = pl.struct(
+            string_expr.alias("_input"),
+            parsed.alias("_result"),
+        ).map_batches(_assert_no_unparsed_dates, return_dtype=pl.Date)
+    return Column(parsed)
+
 
 _SPARK_TS_FORMAT_MAP = [
     ("yyyy", "%Y"),
@@ -119,6 +185,238 @@ def _to_timestamp_no_format_column(col_name: Union[str, Column], *, strict: bool
             result.alias("_result"),
         ).map_batches(_assert_no_unparsed_timestamps, return_dtype=pl.Datetime("us"))
     return Column(result)
+
+
+def _schema_from_string(schema: str) -> Union[DataType, pl.DataType]:
+    normalized = schema.strip()
+    lowered = normalized.lower()
+
+    if lowered.startswith("array<") and lowered.endswith(">"):
+        inner = normalized[6:-1].strip()
+        inner_schema = _schema_from_string(inner)
+        if isinstance(inner_schema, DataType):
+            return ArrayType(inner_schema)
+        return pl.List(inner_schema)
+
+    if lowered.startswith("map<") and lowered.endswith(">"):
+        inner = normalized[4:-1].strip()
+        key_schema, value_schema = [part.strip() for part in inner.split(",", 1)]
+        key_type = _schema_from_string(key_schema)
+        value_type = _schema_from_string(value_schema)
+        if isinstance(key_type, DataType) and isinstance(value_type, DataType):
+            return MapType(key_type, value_type)
+        raise ValueError(f"Unsupported map schema '{schema}'")
+
+    if "," in normalized and "<" not in normalized and ">" not in normalized:
+        fields = []
+        for piece in normalized.split(","):
+            name_and_type = piece.strip().split()
+            if len(name_and_type) < 2:
+                raise ValueError(f"Invalid struct field declaration: '{piece}'")
+            field_name = name_and_type[0]
+            field_type = " ".join(name_and_type[1:])
+            parsed = _schema_from_string(field_type)
+            if not isinstance(parsed, DataType):
+                raise ValueError(f"Unsupported nested struct field type '{field_type}'")
+            from sparkleframe.polarsdf.types import StructField
+
+            fields.append(StructField(field_name, parsed))
+        return StructType(fields)
+
+    try:
+        return spark_name_to_datatype(normalized)
+    except ValueError:
+        pass
+
+    return spark_type_name_to_polars(normalized)
+
+
+def _coerce_json_value(value: Any, schema: Union[DataType, pl.DataType]) -> Any:
+    if value is None:
+        return None
+
+    if isinstance(schema, StringType):
+        return str(value)
+    if isinstance(schema, (IntegerType, LongType, ShortType, ByteType)):
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+    if isinstance(schema, (FloatType, DoubleType, DecimalType)):
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return None
+    if isinstance(schema, BooleanType):
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            lowered = value.strip().lower()
+            if lowered in {"true", "1", "yes"}:
+                return True
+            if lowered in {"false", "0", "no"}:
+                return False
+        return None
+    if isinstance(schema, ArrayType):
+        if not isinstance(value, list):
+            return None
+        return [_coerce_json_value(item, schema.elementType) for item in value]
+    if isinstance(schema, MapType):
+        if not isinstance(value, dict):
+            return None
+        return [
+            {
+                "key": _coerce_json_value(k, schema.keyType),
+                "value": _coerce_json_value(v, schema.valueType),
+            }
+            for k, v in value.items()
+        ]
+    if isinstance(schema, StructType):
+        if not isinstance(value, dict):
+            return None
+        return {field.name: _coerce_json_value(value.get(field.name), field.dataType) for field in schema.fields}
+
+    return value
+
+
+def _series_as_date_sparklike(s: pl.Series) -> pl.Series:
+    """
+    Map column values to ``pl.Date`` with coercion closer to Spark ``cast(x as date)`` than plain
+    :meth:`polars.Series.cast` alone.
+    """
+    if s.len() == 0:
+        return pl.Series(s.name, [], dtype=pl.Date)
+    if s.dtype == pl.Categorical:
+        s = s.cast(pl.Utf8, strict=False)
+    if s.dtype in (pl.Utf8, pl.String):
+        d0 = s.cast(pl.Date, strict=False)
+        vals: list[Any] = s.to_list()
+        d0_list: list[Any] = d0.to_list()
+        out: list[Any] = []
+        for v, d in zip(vals, d0_list):
+            if d is not None:
+                out.append(d)
+                continue
+            if v is None:
+                out.append(None)
+                continue
+            if not isinstance(v, str):
+                out.append(None)
+                continue
+            try:
+                t = pl.Series("_s", [v], dtype=pl.Utf8).str.to_datetime(time_zone="UTC", strict=False)
+            except Exception:
+                out.append(None)
+                continue
+            if t.len() == 0 or t.is_null().all():
+                out.append(None)
+            else:
+                d1 = t.dt.replace_time_zone(None).cast(pl.Date, strict=False)
+                out.append(d1.item())
+        return pl.Series(s.name, out, dtype=pl.Date)
+    return s.cast(pl.Date, strict=False)
+
+
+def _as_date_sparklike_expr(e: pl.Expr) -> pl.Expr:
+    return e.map_batches(_series_as_date_sparklike, return_dtype=pl.Date)
+
+
+def _array_element_at_value(arr: Any, idx_1based: int, *, strict: bool) -> Any:
+    """1-based Spark ``element_at`` / ``try_element_at`` array indexing."""
+    if arr is None:
+        return None
+    if idx_1based == 0:
+        if strict:
+            raise IndexError(
+                "Invalid index 0 for element_at. Spark uses 1-based array indexing; " "index 0 is out of bounds."
+            )
+        return None
+    n = len(arr)
+    polars_idx = idx_1based - 1 if idx_1based > 0 else idx_1based
+    if polars_idx < -n or polars_idx >= n:
+        if strict:
+            raise IndexError(
+                f"Index {idx_1based} out of bounds for array of length {n} "
+                "(Spark 4 ANSI element_at raises SparkArrayIndexOutOfBoundsException)."
+            )
+        return None
+    return arr[polars_idx]
+
+
+def _lookup_map_value_by_key(map_value: Any, key: Any) -> Any:
+    if map_value is None or key is None:
+        return None
+    if isinstance(map_value, dict):
+        return map_value.get(key)
+    if isinstance(map_value, list):
+        for entry in map_value:
+            if isinstance(entry, dict) and entry.get("key") == key:
+                return entry.get("value")
+    return None
+
+
+def _map_key_lookup_expr(col_expr: pl.Expr, key_expr: pl.Expr) -> pl.Expr:
+    """Lookup a key in Spark map layout ``List(Struct(key, value))``."""
+    try:
+        uses_named_column = len(key_expr.meta.root_names()) > 0
+    except Exception:
+        uses_named_column = True
+
+    if uses_named_column:
+        return pl.struct([col_expr.alias("_map"), key_expr.alias("_key")]).map_elements(
+            lambda row: _lookup_map_value_by_key(row["_map"], row["_key"]),
+            return_dtype=pl.Object,
+        )
+
+    return (
+        col_expr.list.eval(
+            pl.when(pl.element().struct.field("key") == key_expr).then(pl.element().struct.field("value"))
+        )
+        .list.drop_nulls()
+        .list.first()
+    )
+
+
+def element_at_column(
+    col_name: Union[str, Column],
+    extraction: Union[str, int, Column],
+    *,
+    strict: bool,
+) -> Column:
+    """
+    Shared implementation for :func:`~sparkleframe.polarsdf.functions.element_at` and
+    ``try_element_at``.
+
+    Spark 4 (ANSI): ``element_at`` raises on invalid array index; ``try_element_at`` returns
+    null. For maps with a string ``extraction``, Spark documents that ``element_at`` treats
+    the string as a **literal key**, while ``try_element_at`` treats it as a **column name**
+    (see SPARK-48766); this helper mirrors that split.
+    """
+    col_expr = _to_expr(col_name) if isinstance(col_name, Column) else pl.col(col_name)
+
+    if isinstance(extraction, Column):
+        key_expr = extraction.to_native()
+        return Column(_map_key_lookup_expr(col_expr, key_expr))
+
+    if isinstance(extraction, pl.Expr):
+        return Column(_map_key_lookup_expr(col_expr, extraction))
+
+    if isinstance(extraction, int):
+        idx = extraction
+
+        def _one(arr: Any) -> Any:
+            return _array_element_at_value(arr, idx, strict=strict)
+
+        return Column(col_expr.map_elements(_one, return_dtype=pl.Object))
+
+    if isinstance(extraction, str):
+        if strict:
+            key_expr = pl.lit(extraction)
+        else:
+            key_expr = pl.col(extraction)
+        return Column(_map_key_lookup_expr(col_expr, key_expr))
+
+    raise TypeError(f"element_at extraction must be int, str, or Column, got {type(extraction).__name__}")
 
 
 class _RankWrapper(Column):

--- a/sparkleframe/polarsdf/functions_test.py
+++ b/sparkleframe/polarsdf/functions_test.py
@@ -9,31 +9,47 @@ import polars as pl
 import pytest
 from polars.testing import assert_frame_equal
 from pyspark.sql.functions import abs as spark_abs
+from pyspark.sql.functions import array_contains as spark_array_contains
 from pyspark.sql.functions import asc as spark_asc
 from pyspark.sql.functions import asc_nulls_first as spark_asc_nulls_first
 from pyspark.sql.functions import asc_nulls_last as spark_asc_nulls_last
 from pyspark.sql.functions import coalesce as spark_coalesce
 from pyspark.sql.functions import col as spark_col
 from pyspark.sql.functions import concat as spark_concat
+from pyspark.sql.functions import current_date as spark_current_date
+from pyspark.sql.functions import date_sub as spark_date_sub
+from pyspark.sql.functions import datediff as spark_datediff
 from pyspark.sql.functions import dense_rank as spark_dense_rank
 from pyspark.sql.functions import desc as spark_desc
 from pyspark.sql.functions import desc_nulls_first as spark_desc_nulls_first
 from pyspark.sql.functions import desc_nulls_last as spark_desc_nulls_last
+from pyspark.sql.functions import element_at as spark_element_at
+from pyspark.sql.functions import explode_outer as spark_explode_outer
+from pyspark.sql.functions import filter as spark_filter
+from pyspark.sql.functions import first as spark_first
+from pyspark.sql.functions import from_json as spark_from_json
 from pyspark.sql.functions import get_json_object as spark_get_json_object
 from pyspark.sql.functions import initcap as spark_initcap
 from pyspark.sql.functions import length as spark_length
 from pyspark.sql.functions import lit as spark_lit
 from pyspark.sql.functions import lower as spark_lower
+from pyspark.sql.functions import map_from_entries as spark_map_from_entries
+from pyspark.sql.functions import map_keys as spark_map_keys
 from pyspark.sql.functions import md5 as spark_md5
 from pyspark.sql.functions import monotonically_increasing_id as spark_monotonically_increasing_id
+from pyspark.sql.functions import months_between as spark_months_between
 from pyspark.sql.functions import now as spark_now
 from pyspark.sql.functions import rank as spark_rank
 from pyspark.sql.functions import regexp_replace as spark_regexp_replace
 from pyspark.sql.functions import round as spark_round
 from pyspark.sql.functions import row_number as spark_row_number
+from pyspark.sql.functions import size as spark_size
 from pyspark.sql.functions import split as spark_split
 from pyspark.sql.functions import struct as spark_struct
+from pyspark.sql.functions import substring as spark_substring
+from pyspark.sql.functions import to_date as spark_to_date
 from pyspark.sql.functions import to_timestamp as spark_to_timestamp
+from pyspark.sql.functions import transform as spark_transform
 from pyspark.sql.functions import trim as spark_trim
 from pyspark.sql.functions import try_element_at as spark_try_element_at
 from pyspark.sql.functions import try_to_date as spark_try_to_date
@@ -53,31 +69,48 @@ from sparkleframe.polarsdf import Window
 from sparkleframe.polarsdf.dataframe import DataFrame
 from sparkleframe.polarsdf.functions import (
     abs,
+    array_contains,
     asc,
     asc_nulls_first,
     asc_nulls_last,
+    broadcast,
     coalesce,
     col,
     concat,
+    current_date,
+    date_sub,
+    datediff,
     dense_rank,
     desc,
     desc_nulls_first,
     desc_nulls_last,
+    element_at,
+    explode,
+    filter,
+    first,
+    from_json,
     get_json_object,
     initcap,
     length,
     lit,
     lower,
+    map_from_entries,
+    map_keys,
     md5,
     monotonically_increasing_id,
+    months_between,
     now,
     rank,
     regexp_replace,
     round,
     row_number,
+    size,
     split,
     struct,
+    substring,
+    to_date,
     to_timestamp,
+    transform,
     trim,
     try_element_at,
     try_to_date,
@@ -85,6 +118,7 @@ from sparkleframe.polarsdf.functions import (
     uuid,
     when,
 )
+from sparkleframe.polarsdf.types import IntegerType, StringType, StructField, StructType
 from sparkleframe.tests.pyspark_test import assert_pyspark_df_equal
 from sparkleframe.tests.utils import assert_sparkle_spark_frame_are_equal, create_spark_df, spark_rows_from_dict
 
@@ -437,6 +471,15 @@ class TestFunctions:
         result_df = polars_df.select(to_timestamp("ts").alias("result"))
 
         assert_sparkle_spark_frame_are_equal(result_df, expected_df)
+
+    def test_to_timestamp_no_format_iso8601_z_against_spark(self, spark) -> None:
+        data = {"createdOn": ["2026-04-26T00:00:00Z"]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        expected_df = spark_df.select(spark_to_timestamp("createdOn").alias("t"))
+        for fn in (to_timestamp, try_to_timestamp):
+            result_df = polars_df.select(fn("createdOn").alias("t"))
+            assert_sparkle_spark_frame_are_equal(result_df, expected_df)
 
     def test_to_timestamp_no_format_malformed_raises(self, spark):
         """Spark 4 to_timestamp(col) without format is ANSI-strict and raises on malformed input."""
@@ -869,6 +912,42 @@ class TestNowAndMonotonicallyIncreasingId:
         assert_sparkle_spark_frame_are_equal(result_df, expected_df)
 
 
+class TestToDate:
+    """Tests for to_date — strict date parsing (Spark 4 ANSI default)."""
+
+    @pytest.mark.parametrize(
+        "date_strs, fmt",
+        [
+            (["1997-02-28", "2024-12-31"], "yyyy-MM-dd"),
+            (["28-02-1997", "31-12-2024"], "dd-MM-yyyy"),
+        ],
+    )
+    def test_to_date_against_spark(self, spark, date_strs, fmt):
+        data = {"d": date_strs}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        expected_df = spark_df.select(spark_to_date("d", fmt).alias("result"))
+        result_df = polars_df.select(to_date("d", fmt).alias("result"))
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)
+
+    @pytest.mark.parametrize(
+        "bad_value, fmt",
+        [
+            ("bad", "yyyy-MM-dd"),
+            ("1997-02-28", "dd-MM-yyyy"),
+        ],
+    )
+    def test_to_date_malformed_raises(self, spark, bad_value, fmt):
+        """Spark 4 to_date is ANSI-strict and raises on malformed or pattern-mismatched input."""
+        polars_df = DataFrame(pl.DataFrame({"d": [bad_value]}))
+        with pytest.raises(Exception):
+            polars_df.select(to_date("d", fmt).alias("result")).to_native_df()
+
+        spark_df = spark.createDataFrame([(bad_value,)], ["d"])
+        with pytest.raises(Exception):
+            spark_df.select(spark_to_date("d", fmt).alias("result")).collect()
+
+
 class TestTryToTimestamp:
     """Tests for try_to_timestamp — verifies null-safe parsing behaviour."""
 
@@ -923,6 +1002,24 @@ class TestTryToTimestamp:
         result_df = polars_df.select(try_to_timestamp("ts", fmt).alias("result"))
         assert_sparkle_spark_frame_are_equal(result_df, expected_df)
 
+    def test_try_to_timestamp_format_iso_t_separator_returns_null(self, spark) -> None:
+        data = {"ts": ["2024-03-15T10:20:30", "2024-03-15 10:20:30"]}
+        fmt = "yyyy-MM-dd HH:mm:ss"
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        expected_df = spark_df.selectExpr(f"try_to_timestamp(ts, '{fmt}') as t")
+        result_df = polars_df.select(try_to_timestamp("ts", fmt).alias("t"))
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)
+
+    def test_to_timestamp_with_format_iso_t_separator_raises(self, spark) -> None:
+        fmt = "yyyy-MM-dd HH:mm:ss"
+        polars_df = DataFrame(pl.DataFrame({"ts": ["2024-03-15T10:20:30"]}))
+        with pytest.raises(Exception):
+            polars_df.select(to_timestamp("ts", fmt).alias("t")).to_native_df()
+        spark_df = spark.createDataFrame([("2024-03-15T10:20:30",)], ["ts"])
+        with pytest.raises(Exception):
+            spark_df.selectExpr(f"to_timestamp(ts, '{fmt}') as t").collect()
+
     def test_try_to_timestamp_accepts_column_input(self, spark):
         data = {"ts": ["2023-01-01 12:34:56"]}
         polars_df = DataFrame(pl.DataFrame(data))
@@ -934,6 +1031,26 @@ class TestTryToTimestamp:
 
 class TestTryToDate:
     """Tests for try_to_date — verifies null-safe date parsing."""
+
+    @pytest.mark.parametrize(
+        "date_strs, fmt",
+        [
+            (["1997-02-28", "2024-12-31"], "yyyy-MM-dd"),
+            (["28-02-1997", "31-12-2024"], "dd-MM-yyyy"),
+        ],
+    )
+    def test_try_to_date_valid_matches_to_date(self, spark, date_strs, fmt):
+        data = {"d": date_strs}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+
+        result_strict = polars_df.select(to_date("d", fmt).alias("result")).to_native_df()
+        result_try = polars_df.select(try_to_date("d", fmt).alias("result")).to_native_df()
+        assert result_strict["result"].to_list() == result_try["result"].to_list()
+
+        expected_df = spark_df.select(spark_try_to_date("d", fmt).alias("result"))
+        result_df = polars_df.select(try_to_date("d", fmt).alias("result"))
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)
 
     def test_try_to_date_default_format_malformed_returns_null(self, spark):
         data = {"d": ["1997-02-28", "2024-12-31", "bad", None]}
@@ -1041,36 +1158,39 @@ class TestTryElementAt:
         )
         assert result_spark_df.collect()[0]["v"] is None
 
-    def test_map_key_present(self, spark):
+    def test_map_literal_key_via_lit_column(self, spark) -> None:
+        """Literal map keys use ``lit`` in PySpark; ``try_element_at`` does not treat bare strings as literals."""
         df = pl.DataFrame({"m": [[{"key": "a", "value": 1.0}, {"key": "b", "value": 2.0}]]})
         polars_df = DataFrame(df)
-        result = polars_df.select(try_element_at("m", "a").alias("v")).to_native_df()
-        assert result["v"][0] == 1.0
         spark_df = spark.createDataFrame(
             [({"a": 1.0, "b": 2.0},)],
             schema=SparkStructType([SparkStructField("m", SparkMapType(SparkStringType(), SparkDoubleType()), True)]),
         )
-        expected = spark_df.select(spark_try_element_at(spark_col("m"), spark_lit("a")).alias("v"))
-        result_spark_df = create_spark_df(spark, polars_df.select(try_element_at("m", "a").alias("v")))
-        assert_pyspark_df_equal(result_spark_df, expected, ignore_nullable=True)
+        sf_result = polars_df.select(try_element_at("m", lit("a")).alias("v"))
+        spark_result = spark_df.select(spark_try_element_at(spark_col("m"), spark_lit("a")).alias("v"))
+        assert_sparkle_spark_frame_are_equal(sf_result, spark_result)
 
-    def test_map_key_absent_returns_null(self, spark):
-        df = pl.DataFrame({"m": [[{"key": "a", "value": 1.0}, {"key": "b", "value": 2.0}]]})
+    def test_map_string_extraction_is_column_name(self, spark) -> None:
+        """``try_element_at(map, 'col')`` uses column ``col`` as the key (SPARK-48766), not literal ``'col'``."""
+        df = pl.DataFrame(
+            {
+                "m": [[{"key": "a", "value": 1.0}, {"key": "b", "value": 2.0}]],
+                "lookup": ["a"],
+            }
+        )
         polars_df = DataFrame(df)
-        result = polars_df.select(try_element_at("m", "c").alias("v")).to_native_df()
-        assert result["v"][0] is None
         spark_df = spark.createDataFrame(
-            [({"a": 1.0, "b": 2.0},)],
-            schema=SparkStructType([SparkStructField("m", SparkMapType(SparkStringType(), SparkDoubleType()), True)]),
+            [({"a": 1.0, "b": 2.0}, "a")],
+            schema=SparkStructType(
+                [
+                    SparkStructField("m", SparkMapType(SparkStringType(), SparkDoubleType()), True),
+                    SparkStructField("lookup", SparkStringType(), True),
+                ]
+            ),
         )
-        expected = spark_df.select(spark_try_element_at(spark_col("m"), spark_lit("c")).alias("v"))
-        null_double_schema = SparkStructType([SparkStructField("v", SparkDoubleType(), True)])
-        result_spark_df = create_spark_df(
-            spark,
-            polars_df.select(try_element_at("m", "c").alias("v")),
-            schema=null_double_schema,
-        )
-        assert_pyspark_df_equal(result_spark_df, expected, ignore_nullable=True)
+        sf_result = polars_df.select(try_element_at("m", "lookup").alias("v"))
+        spark_result = spark_df.select(spark_try_element_at(spark_col("m"), spark_col("lookup")).alias("v"))
+        assert_sparkle_spark_frame_are_equal(sf_result, spark_result)
 
     def test_accepts_column_input(self, spark):
         df = pl.DataFrame({"arr": [["x", "y"]]})
@@ -1081,3 +1201,239 @@ class TestTryElementAt:
         expected = spark_df.select(spark_try_element_at(spark_col("arr"), spark_lit(1)).alias("v"))
         result_spark_df = create_spark_df(spark, polars_df.select(try_element_at(col("arr"), 1).alias("v")))
         assert_pyspark_df_equal(result_spark_df, expected, ignore_nullable=True)
+
+
+class TestElementAt:
+    """``element_at`` is ANSI-strict on invalid array indices (Spark 4); not an alias of ``try_element_at``."""
+
+    @staticmethod
+    def _spark_df_string_array(spark, values: list):
+        return spark.createDataFrame(
+            [(values,)],
+            schema=SparkStructType([SparkStructField("arr", SparkArrayType(SparkStringType()), True)]),
+        )
+
+    def test_array_valid_index_matches_spark(self, spark) -> None:
+        df = pl.DataFrame({"arr": [["a", "b", "c"]]})
+        polars_df = DataFrame(df)
+        spark_df = self._spark_df_string_array(spark, ["a", "b", "c"])
+        sf_result = polars_df.select(element_at("arr", 2).alias("v"))
+        spark_result = spark_df.select(spark_element_at(spark_col("arr"), spark_lit(2)).alias("v"))
+        assert_sparkle_spark_frame_are_equal(sf_result, spark_result)
+
+    def test_array_oob_raises_like_spark(self, spark) -> None:
+        """Spark 4 ANSI: out-of-bounds ``element_at`` raises; ``try_element_at`` returns null."""
+        df = pl.DataFrame({"arr": [["a", "b", "c"]]})
+        polars_df = DataFrame(df)
+        spark_df = self._spark_df_string_array(spark, ["a", "b", "c"])
+        with pytest.raises(Exception):
+            spark_df.select(spark_element_at(spark_col("arr"), spark_lit(4))).collect()
+        with pytest.raises(Exception):
+            polars_df.select(element_at("arr", 4)).to_native_df()
+        # Lenient counterpart must not raise.
+        assert polars_df.select(try_element_at("arr", 4).alias("v")).to_native_df()["v"][0] is None
+
+    def test_array_zero_index_raises_like_spark(self, spark) -> None:
+        df = pl.DataFrame({"arr": [["a", "b", "c"]]})
+        polars_df = DataFrame(df)
+        spark_df = self._spark_df_string_array(spark, ["a", "b", "c"])
+        with pytest.raises(Exception):
+            spark_df.select(spark_element_at(spark_col("arr"), spark_lit(0))).collect()
+        with pytest.raises(Exception):
+            polars_df.select(element_at("arr", 0)).to_native_df()
+
+    def test_map_literal_string_key_matches_spark(self, spark) -> None:
+        """``element_at(map, 'key')`` uses a literal key (unlike ``try_element_at`` string = column name)."""
+        df = pl.DataFrame({"m": [[{"key": "a", "value": 1.0}, {"key": "b", "value": 2.0}]]})
+        polars_df = DataFrame(df)
+        spark_df = spark.createDataFrame(
+            [({"a": 1.0, "b": 2.0},)],
+            schema=SparkStructType([SparkStructField("m", SparkMapType(SparkStringType(), SparkDoubleType()), True)]),
+        )
+        sf_result = polars_df.select(element_at("m", "a").alias("v"))
+        spark_result = spark_df.select(spark_element_at(spark_col("m"), spark_lit("a")).alias("v"))
+        assert_sparkle_spark_frame_are_equal(sf_result, spark_result)
+
+    def test_map_missing_literal_key_returns_null(self, spark) -> None:
+        df = pl.DataFrame({"m": [[{"key": "a", "value": 1.0}, {"key": "b", "value": 2.0}]]})
+        polars_df = DataFrame(df)
+        spark_df = spark.createDataFrame(
+            [({"a": 1.0, "b": 2.0},)],
+            schema=SparkStructType([SparkStructField("m", SparkMapType(SparkStringType(), SparkDoubleType()), True)]),
+        )
+        sf_result = polars_df.select(element_at("m", "c").alias("v"))
+        spark_result = spark_df.select(spark_element_at(spark_col("m"), spark_lit("c")).alias("v"))
+        assert_sparkle_spark_frame_are_equal(sf_result, spark_result)
+
+
+class TestSubstring:
+    def test_substring_against_spark(self, spark) -> None:
+        data = {"s": ["hELlo woRLd", None, ""]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        expected_df = spark_df.select(spark_substring("s", spark_lit(2), spark_lit(3)).alias("sub"))
+        result_df = polars_df.select(substring("s", 2, 3).alias("sub"))
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)
+
+
+class TestArrayFunctions:
+    def test_array_contains_and_size_against_spark(self, spark) -> None:
+        data = {"arr": [[1, 2, 3], [10]]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        expected_df = spark_df.select(
+            spark_array_contains("arr", spark_lit(2)).alias("has2"),
+            spark_size("arr").alias("sz"),
+        )
+        result_df = polars_df.select(
+            array_contains("arr", 2).alias("has2"),
+            size("arr").alias("sz"),
+        )
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)
+
+    def test_array_filter_and_transform_against_spark(self, spark) -> None:
+        data = {"arr": [[1, 2, 3], [10]]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        expected_df = spark_df.select(
+            spark_filter("arr", lambda x: x > 1).alias("flt"),
+            spark_transform("arr", lambda x: x * 2).alias("dbl"),
+        )
+        result_df = polars_df.select(
+            filter("arr", lambda c: c > 1).alias("flt"),
+            transform("arr", lambda c: c * 2).alias("dbl"),
+        )
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)
+
+    def test_explode_against_spark(self, spark) -> None:
+        data = {"a": [[1, 2], None, []]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        expected_df = spark_df.select(spark_explode_outer("a").alias("e"))
+        result_df = polars_df.select(explode("a").alias("e"))
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)
+
+
+class TestDateFunctions:
+    def test_date_sub_and_datediff_against_spark(self, spark) -> None:
+        data = {"d": [None, "2024-01-10", "2024-01-01"]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        expected_df = spark_df.select(
+            spark_date_sub(spark_col("d"), spark_lit(2)).alias("sub"),
+            spark_datediff(spark_lit("2024-01-20"), spark_col("d")).alias("dd"),
+        )
+        result_df = polars_df.select(
+            date_sub("d", 2).alias("sub"),
+            datediff(lit("2024-01-20"), "d").alias("dd"),
+        )
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)
+
+    def test_datediff_iso8601_string_against_spark(self, spark) -> None:
+        data = {"a": ["2026-04-26T00:00:00Z"]}
+        end = "2026-04-27"
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        expected_df = spark_df.select(spark_datediff(spark_lit(end), spark_col("a")).alias("d"))
+        result_df = polars_df.select(datediff(lit(end), "a").alias("d"))
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)
+
+    def test_datetime_ge_date_sub_against_spark(self, spark) -> None:
+        data = {"created": ["2026-04-26T00:00:00Z", "2026-01-01T00:00:00Z", None]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        expected_df = spark_df.select(
+            (spark_col("created") >= spark_date_sub(spark_current_date(), spark_lit(30))).alias("passes_30d")
+        )
+        result_df = polars_df.select((col("created") >= date_sub(current_date(), 30)).alias("passes_30d"))
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)
+
+    def test_months_between_against_spark(self, spark) -> None:
+        data = {"start": ["2024-01-15"], "end": ["2024-03-20"]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        result_spark_df = create_spark_df(spark, polars_df.select(months_between("end", "start").alias("mb")))
+        expected_df = spark_df.select(spark_months_between("end", "start").alias("mb"))
+        assert_pyspark_df_equal(result_spark_df, expected_df, precision=8)
+
+
+class TestMapFunctions:
+    def test_map_keys_against_spark(self, spark) -> None:
+        data = {"m": [{"a": 1.0, "b": 2.0}]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(
+            [({"a": 1.0, "b": 2.0},)],
+            schema=SparkStructType([SparkStructField("m", SparkMapType(SparkStringType(), SparkDoubleType()), True)]),
+        )
+        expected_df = spark_df.select(spark_map_keys("m").alias("keys"))
+        result_df = polars_df.select(map_keys("m").alias("keys"))
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)
+
+    def test_map_from_entries_against_spark(self, spark) -> None:
+        from pyspark.sql import Row
+
+        entries = [Row(key="a", value=1), Row(key="b", value=2)]
+        spark_df = spark.createDataFrame([Row(entries=entries)])
+        polars_df = DataFrame(pl.DataFrame({"entries": [[{"key": "a", "value": 1}, {"key": "b", "value": 2}]]}))
+        expected_df = spark_df.select(spark_map_from_entries("entries").alias("m"))
+        result_df = polars_df.select(map_from_entries("entries").alias("m"))
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)
+
+
+class TestFromJson:
+    def test_from_json_struct_against_spark(self, spark) -> None:
+        payload = '{"field1": "hello", "field2": 999}'
+        data = {"j": [payload]}
+        schema = StructType([StructField("field1", StringType()), StructField("field2", IntegerType())])
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        spark_schema = SparkStructType(
+            [
+                SparkStructField("field1", SparkStringType()),
+                SparkStructField("field2", SparkIntegerType()),
+            ]
+        )
+        expected_df = spark_df.select(spark_from_json("j", spark_schema).alias("parsed"))
+        result_df = polars_df.select(from_json("j", schema).alias("parsed"))
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)
+
+    def test_from_json_malformed_returns_null(self, spark) -> None:
+        schema = StructType([StructField("field1", StringType()), StructField("field2", IntegerType())])
+        spark_schema = SparkStructType(
+            [
+                SparkStructField("field1", SparkStringType()),
+                SparkStructField("field2", SparkIntegerType()),
+            ]
+        )
+        valid_data = {"j": ['{"field1": "ok", "field2": 1}']}
+        polars_valid = DataFrame(pl.DataFrame(valid_data))
+        spark_valid = spark.createDataFrame(spark_rows_from_dict(valid_data), list(valid_data.keys()))
+        assert_sparkle_spark_frame_are_equal(
+            polars_valid.select(from_json("j", schema).alias("parsed")),
+            spark_valid.select(spark_from_json("j", spark_schema).alias("parsed")),
+        )
+
+        bad_data = {"j": ["not-json"]}
+        polars_bad = DataFrame(pl.DataFrame(bad_data))
+        result = polars_bad.select(from_json("j", schema).alias("parsed")).to_native_df()
+        assert result["parsed"][0] is None
+
+        spark_bad = spark.createDataFrame(spark_rows_from_dict(bad_data), list(bad_data.keys()))
+        spark_row = spark_bad.select(spark_from_json("j", spark_schema).alias("parsed")).collect()[0][0]
+        assert spark_row is None or (spark_row.field1 is None and spark_row.field2 is None)
+
+
+class TestFirstAgg:
+    def test_first_agg_against_spark(self, spark) -> None:
+        data = {"g": [1, 1, 2, 2], "v": [10, 20, 30, 40]}
+        polars_df = DataFrame(pl.DataFrame(data)).sort("g", "v")
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys())).orderBy("g", "v")
+        expected_df = spark_df.groupBy("g").agg(spark_first("v").alias("fv"))
+        result_df = polars_df.groupBy("g").agg(first("v").alias("fv"))
+        assert_sparkle_spark_frame_are_equal(result_df.orderBy("g"), expected_df.orderBy("g"))
+
+
+class TestBroadcast:
+    def test_broadcast_returns_same_dataframe(self) -> None:
+        d = DataFrame(pl.DataFrame({"x": [1]}))
+        assert broadcast(d) is d

--- a/sparkleframe/polarsdf/group.py
+++ b/sparkleframe/polarsdf/group.py
@@ -3,7 +3,8 @@ from typing import Union
 import polars as pl
 
 from sparkleframe.base.dataframe import DataFrame
-from sparkleframe.polarsdf import Column
+from sparkleframe.polarsdf.column import Column
+from sparkleframe.polarsdf.column_helpers import _polars_schema_for
 
 
 class GroupedData:
@@ -13,7 +14,8 @@ class GroupedData:
         self.group_cols = [col.to_native() if isinstance(col, Column) else pl.col(col) for col in group_cols]
 
     def agg(self, *exprs: Union[str, Column]) -> DataFrame:
-        pl_exprs = [e.to_native() if isinstance(e, Column) else e for e in exprs]
+        with _polars_schema_for(self.df.schema):
+            pl_exprs = [e.to_native() if isinstance(e, Column) else e for e in exprs]
         grouped = self.df.group_by(*self.group_cols).agg(pl_exprs)
         return type(self.spark_df)(grouped)
 

--- a/sparkleframe/polarsdf/types.py
+++ b/sparkleframe/polarsdf/types.py
@@ -1,39 +1,9 @@
 import json
 import re
-from typing import Any, Dict, Iterator, List, Optional, Union
+from dataclasses import dataclass
+from typing import Any, Dict, Iterator, List, Optional, Type, Union
 
 import polars as pl
-
-SPARK_TYPE_NAME_MAP: dict[str, pl.DataType] = {
-    "string": pl.Utf8,
-    "int": pl.Int32,
-    "integer": pl.Int32,
-    "bigint": pl.Int64,
-    "long": pl.Int64,
-    "short": pl.Int16,
-    "smallint": pl.Int16,
-    "tinyint": pl.Int8,
-    "byte": pl.Int8,
-    "float": pl.Float32,
-    "double": pl.Float64,
-    "boolean": pl.Boolean,
-    "date": pl.Date,
-    "timestamp": pl.Datetime,
-    "binary": pl.Binary,
-}
-
-
-def spark_type_name_to_polars(name: str) -> pl.DataType:
-    key = name.strip().lower()
-    decimal_match = re.match(r"decimal\(\s*(\d+)\s*,\s*(\d+)\s*\)", key)
-    if decimal_match:
-        precision = int(decimal_match.group(1))
-        scale = int(decimal_match.group(2))
-        return pl.Decimal(precision=precision, scale=scale)
-    try:
-        return SPARK_TYPE_NAME_MAP[key]
-    except KeyError:
-        raise ValueError(f"Unsupported Spark type name for try_cast: '{name}'") from None
 
 
 class DataType:
@@ -159,6 +129,188 @@ class BinaryType(DataType):
 
     def to_native(self):
         return pl.Binary
+
+
+# ---------------------------------------------------------------------------
+# Scalar type registry (single source of truth for Spark SQL name <-> Polars <-> DataType)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _ScalarTypeEntry:
+    """One scalar Spark/Polars/SparkleFrame type triple."""
+
+    spark_name: str
+    polars_dtype: Type[pl.DataType]
+    datatype_cls: Type[DataType]
+    aliases: tuple[str, ...] = ()
+    ddl_name: Optional[str] = None
+
+
+def _scalar_registry_entries() -> list[_ScalarTypeEntry]:
+    """Build registry after scalar DataType classes are defined."""
+    return [
+        _ScalarTypeEntry("tinyint", pl.Int8, ByteType, aliases=("byte",)),
+        _ScalarTypeEntry("smallint", pl.Int16, ShortType, aliases=("short",)),
+        _ScalarTypeEntry("int", pl.Int32, IntegerType, aliases=("integer",)),
+        _ScalarTypeEntry("bigint", pl.Int64, LongType, aliases=("long",)),
+        _ScalarTypeEntry("float", pl.Float32, FloatType),
+        _ScalarTypeEntry("double", pl.Float64, DoubleType),
+        _ScalarTypeEntry("boolean", pl.Boolean, BooleanType),
+        _ScalarTypeEntry("string", pl.Utf8, StringType),
+        _ScalarTypeEntry("date", pl.Date, DateType),
+        _ScalarTypeEntry("timestamp", pl.Datetime, TimestampType),
+        _ScalarTypeEntry("binary", pl.Binary, BinaryType),
+    ]
+
+
+_SCALAR_TYPE_REGISTRY: list[_ScalarTypeEntry] = _scalar_registry_entries()
+
+
+def _build_spark_name_to_polars() -> dict[str, pl.DataType]:
+    out: dict[str, pl.DataType] = {}
+    for entry in _SCALAR_TYPE_REGISTRY:
+        out[entry.spark_name] = entry.polars_dtype
+        for alias in entry.aliases:
+            out[alias] = entry.polars_dtype
+    return out
+
+
+def _build_spark_name_to_datatype_cls() -> dict[str, Type[DataType]]:
+    out: dict[str, Type[DataType]] = {}
+    for entry in _SCALAR_TYPE_REGISTRY:
+        out[entry.spark_name] = entry.datatype_cls
+        for alias in entry.aliases:
+            out[alias] = entry.datatype_cls
+    return out
+
+
+def _build_polars_to_spark_name() -> dict[Type[pl.DataType], str]:
+    return {entry.polars_dtype: entry.spark_name for entry in _SCALAR_TYPE_REGISTRY}
+
+
+def _build_polars_to_datatype_cls() -> dict[Type[pl.DataType], Type[DataType]]:
+    return {entry.polars_dtype: entry.datatype_cls for entry in _SCALAR_TYPE_REGISTRY}
+
+
+_SPARK_NAME_TO_POLARS: dict[str, pl.DataType] = _build_spark_name_to_polars()
+_SPARK_NAME_TO_DATATYPE_CLS: dict[str, Type[DataType]] = _build_spark_name_to_datatype_cls()
+_POLARS_TO_SPARK_NAME: dict[Type[pl.DataType], str] = _build_polars_to_spark_name()
+_POLARS_TO_DATATYPE_CLS: dict[Type[pl.DataType], Type[DataType]] = _build_polars_to_datatype_cls()
+
+# Backward-compatible alias used by column tests and casts.
+SPARK_TYPE_NAME_MAP: dict[str, pl.DataType] = _SPARK_NAME_TO_POLARS
+
+# Unsigned Polars dtypes (not in the scalar registry; used for display / schema coercion).
+_POLARS_UNSIGNED_TO_SPARK_NAME: dict[Type[pl.DataType], str] = {
+    pl.UInt8: "tinyint",
+    pl.UInt16: "smallint",
+    pl.UInt32: "int",
+    pl.UInt64: "bigint",
+}
+
+_POLARS_UNSIGNED_TO_DATATYPE_CLS: dict[Type[pl.DataType], Type[DataType]] = {
+    pl.UInt8: ByteType,
+    pl.UInt16: ShortType,
+    pl.UInt32: IntegerType,
+    pl.UInt64: LongType,
+}
+
+# DDL-only: Polars dtype -> Spark SQL type for ``createDataFrame([], ddl)``.
+_POLARS_DDL_SPARK_NAME_OVERRIDES: dict[Type[pl.DataType], str] = {
+    pl.Null: "void",
+    pl.UInt8: "smallint",
+    pl.UInt16: "int",
+    pl.UInt32: "bigint",
+    pl.UInt64: "decimal(20,0)",
+    pl.Duration: "bigint",
+}
+
+
+def spark_type_name_to_polars(name: str) -> pl.DataType:
+    key = name.strip().lower()
+    decimal_match = re.match(r"decimal\(\s*(\d+)\s*,\s*(\d+)\s*\)", key)
+    if decimal_match:
+        precision = int(decimal_match.group(1))
+        scale = int(decimal_match.group(2))
+        return pl.Decimal(precision=precision, scale=scale)
+    try:
+        return _SPARK_NAME_TO_POLARS[key]
+    except KeyError:
+        raise ValueError(f"Unsupported Spark type name for try_cast: '{name}'") from None
+
+
+def spark_name_to_datatype(name: str) -> DataType:
+    """Instantiate a SparkleFrame ``DataType`` from a Spark SQL type name."""
+    key = name.strip().lower()
+    decimal_match = re.match(r"decimal\(\s*(\d+)\s*,\s*(\d+)\s*\)", key)
+    if decimal_match:
+        precision = int(decimal_match.group(1))
+        scale = int(decimal_match.group(2))
+        return DecimalType(precision, scale)
+    try:
+        return _SPARK_NAME_TO_DATATYPE_CLS[key]()
+    except KeyError:
+        raise ValueError(f"Unsupported Spark type name: '{name}'") from None
+
+
+def polars_dtype_to_spark_sql_name(dtype: pl.DataType) -> str:
+    """
+    Map a Polars dtype to a Spark SQL type name for ``DataFrame.dtypes``.
+
+    Complex types (struct/list/decimal) are formatted recursively; unknown types fall back to ``str(dtype)``.
+    """
+    if isinstance(dtype, pl.Decimal):
+        return f"decimal({dtype.precision},{dtype.scale})"
+    if isinstance(dtype, pl.Struct):
+        fields_str = ",".join(f"{field.name}:{polars_dtype_to_spark_sql_name(field.dtype)}" for field in dtype.fields)
+        return f"struct<{fields_str}>"
+    if isinstance(dtype, (pl.List, pl.Array)):
+        return "array"
+    for polars_type, spark_name in _POLARS_UNSIGNED_TO_SPARK_NAME.items():
+        if isinstance(dtype, polars_type):
+            return spark_name
+    for polars_type, spark_name in _POLARS_TO_SPARK_NAME.items():
+        if isinstance(dtype, polars_type):
+            return spark_name
+    if dtype == pl.Time:
+        return "time"
+    if dtype == pl.Duration:
+        return "interval"
+    if dtype == pl.Object:
+        return "binary"
+    if dtype in (pl.Utf8, pl.String):
+        return "string"
+    return str(dtype)
+
+
+def polars_dtype_to_spark_ddl_name(dtype: pl.DataType) -> str:
+    """Map a Polars dtype to Spark SQL for empty-frame ``createDataFrame([], ddl)``."""
+    if isinstance(dtype, (pl.List, pl.Array, pl.Struct, pl.Object)):
+        return "string"
+    if dtype in _POLARS_DDL_SPARK_NAME_OVERRIDES:
+        return _POLARS_DDL_SPARK_NAME_OVERRIDES[dtype]
+    if isinstance(dtype, pl.Decimal):
+        return f"decimal({dtype.precision},{dtype.scale})"
+    if isinstance(dtype, pl.Datetime):
+        return "timestamp"
+    for polars_type, spark_name in _POLARS_TO_SPARK_NAME.items():
+        if isinstance(dtype, polars_type):
+            return spark_name
+    return "string"
+
+
+def polars_dtype_to_spark_datatype(dtype: pl.DataType) -> DataType:
+    """Instantiate a scalar SparkleFrame ``DataType`` from a Polars dtype (no nested types)."""
+    if dtype == pl.Null:
+        return StringType()
+    for polars_type, cls in _POLARS_UNSIGNED_TO_DATATYPE_CLS.items():
+        if isinstance(dtype, polars_type):
+            return cls()
+    for polars_type, cls in _POLARS_TO_DATATYPE_CLS.items():
+        if isinstance(dtype, polars_type):
+            return cls()
+    raise TypeError(f"Unsupported dtype '{dtype}'")
 
 
 class StructField(DataType):

--- a/sparkleframe/polarsdf/types_test.py
+++ b/sparkleframe/polarsdf/types_test.py
@@ -10,6 +10,20 @@ from sparkleframe.polarsdf import types as sft
 from sparkleframe.tests.utils import _get_json_from_dataframe, assert_sparkle_spark_frame_are_equal
 
 
+class TestScalarTypeRegistry:
+    def test_registry_roundtrip_consistency(self) -> None:
+        canonical_spark_names = {entry.spark_name for entry in sft._SCALAR_TYPE_REGISTRY}
+        assert canonical_spark_names == set(sft._POLARS_TO_SPARK_NAME.values())
+        assert canonical_spark_names <= set(sft._SPARK_NAME_TO_POLARS.keys())
+
+        for entry in sft._SCALAR_TYPE_REGISTRY:
+            assert sft.spark_type_name_to_polars(entry.spark_name) == entry.polars_dtype
+            assert entry.datatype_cls().to_native() == entry.polars_dtype
+            for alias in entry.aliases:
+                assert sft.spark_type_name_to_polars(alias) == entry.polars_dtype
+                assert sft.spark_name_to_datatype(alias).typeName() == entry.datatype_cls().typeName()
+
+
 class TestTypes:
 
     @pytest.mark.parametrize(

--- a/sparkleframe/polarsdf/types_utils.py
+++ b/sparkleframe/polarsdf/types_utils.py
@@ -1,8 +1,10 @@
+import json
 from dataclasses import dataclass, field
-from typing import List, Optional, Iterable, Any, Dict
-from sparkleframe.polarsdf import types as sft
+from typing import Any, Dict, Iterable, List, Optional
+
 import polars as pl
 
+from sparkleframe.polarsdf import types as sft
 from sparkleframe.polarsdf.types import StructType
 
 
@@ -387,7 +389,14 @@ class _MapTypeUtils:
                     for sf in dt.fields
                 }
 
-            # leaf
+            # leaf — Spark semantics: explicit StringType coerces non-null values to str.
+            if isinstance(dt, sft.StringType):
+                if val is None:
+                    return None
+                if isinstance(val, (dict, list)):
+                    return json.dumps(val, default=str)
+                return str(val)
+
             return val
 
         cols = {name: [] for name in colnames}

--- a/sparkleframe/tests/utils.py
+++ b/sparkleframe/tests/utils.py
@@ -14,6 +14,15 @@ from pyspark.sql.dataframe import DataFrame as SparkDataFrame
 from pyspark.sql.types import StructType as SparkStructType
 
 from sparkleframe.polarsdf import DataFrame
+from sparkleframe.polarsdf.types import polars_dtype_to_spark_ddl_name
+
+
+def _ddl_schema_from_polars_frame(frame: pl.DataFrame) -> str:
+    parts: list[str] = []
+    for name in frame.columns:
+        sql_type = polars_dtype_to_spark_ddl_name(frame.schema[name])
+        parts.append(f"{name} {sql_type}")
+    return ", ".join(parts)
 
 
 def spark_rows_from_dict(data: dict[str, list[Any]]) -> list[tuple[Any, ...]]:
@@ -51,6 +60,8 @@ def create_spark_df(
     if not rows:
         if schema is not None:
             return spark.createDataFrame([], schema)
+        if cols:
+            return spark.createDataFrame([], _ddl_schema_from_polars_frame(native))
         return spark.createDataFrame(pd.DataFrame(native.to_arrow().to_pandas()))
 
     row_tuples = [tuple(r[c] for c in cols) for r in rows]


### PR DESCRIPTION
## Summary

Expands `functions` with JSON, aggregates, arrays, maps, and dates; adds Spark 4.1 parity tests in existing `*_test.py` modules. Rebased on `main` after #96.

### Functions / helpers
- **JSON:** `get_json_object`, `from_json` (schema string or `DataType`), nested coercion for Spark parity
- **Aggregates / maps / arrays:** `collect_list`, `collect_set`, `map_from_entries`, `map_keys`, `transform`, `filter`, `array_contains`, `size`, `explode`
- **Dates:** `current_date`, `date_sub`, `datediff`, `months_between`; **`to_date`** (ANSI-strict) and **`try_to_date`** via shared `_to_date_column` (format-only parse, no silent cast fallback)
- **Strings / misc:** `substring`, `broadcast` stub, `concat` / `struct` improvements
- **`element_at` / `try_element_at`:** Spark 4 map/array semantics (strict vs lenient, SPARK-48766 string-key behaviour)
- **`functions_helpers`:** `_schema_from_string`, `element_at_column`, date/timestamp parsing (builds on #96)
- **Helpers cleanup:** moved `_md5_sparklike`, `_re_split_sparklike`, `_now_batch`, `_substring_sparklike` from `column_helpers.py` to `functions_helpers.py` (only used by `functions.py`)

### Type registry
- **`_SCALAR_TYPE_REGISTRY`** in `types.py`: single source for Spark SQL name ↔ Polars dtype ↔ SparkleFrame `DataType`
- Replaces duplicated maps in `dataframe_helpers`, `functions_helpers`, and `tests/utils` (DDL helpers use registry + unsigned/void overrides)

### Tests
- Parity coverage lives in **`functions_test.py`** and **`dataframe_test.py`** (no separate `spark_v4_parity_test.py`)
- **`to_date` / `try_to_date` / `to_timestamp` / `try_to_timestamp`:** valid rows plus malformed inputs (`assert_sparkle_spark_frame_are_equal` / `pytest.raises`)
- **`types_test.py`:** registry round-trip consistency test
- **`tests/utils`:** `create_spark_df`, frame comparison helpers for empty-frame DDL

### Other
- `group.agg` schema context fix; `types_utils` StringType leaf coercion
- **`AGENTS.md`:** strict/lenient parse testing requirements

## Stack

**PR 3/4** — rebased on `main` (#95 + #96 merged). Next: #98

## Test plan

- [x] `make test f=sparkleframe/polarsdf/functions_test.py`
- [x] `make test f=sparkleframe/polarsdf/types_test.py`
- [x] `make test` (full suite)
- [ ] `make coverage`