### PR TITLE
feat(polarsdf): more Column/DF/functions + helpers refactor

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,4 +140,6 @@ When editing Python in this repo:
 - Add type hints on all function parameters and return types.
 - Run `make black` and `make lint` to validate code structure.
 - Avoid leaving dead code or dead methods.
+- **Always run tests inside Docker** via `make test` (not bare `pytest`). The Docker container
+  sets required env vars (e.g. `TIMEZONE`) that the Spark fixture depends on.
 - Run affected tests, e.g. `make test f=sparkleframe/polarsdf/functions_test.py`.

--- a/docs/known_gaps.md
+++ b/docs/known_gaps.md
@@ -69,6 +69,69 @@ early when either dtype is `None`.
    the unknown-dtype path to avoid regressions in same-type operations (a
    previous broad attempt was reverted for this reason).
 
+## `transform` with struct-producing lambdas
+
+**Affected operations:** `F.transform(col, lambda x: F.struct(...))`
+
+Polars' `list.eval` does not support `pl.struct` expressions, so SparkleFrame
+falls back to `map_batches`.  The batch callback infers the struct dtype at
+runtime from the data, and the `return_dtype` hint is constructed from the
+struct field names (defaulting unknown types to `Utf8`).
+
+This means:
+
+- **`_struct_parts` metadata propagation is required:** `WhenBuilder`
+  (`when/otherwise`) propagates `_struct_parts` from the struct branch so that
+  `transform` can build the return dtype.  If this metadata is lost (e.g.
+  through a chain not yet covered), the fallback parses `.alias("name")`
+  patterns from the expression's string representation.
+
+- **Performance:** `map_batches` processes one row at a time in the struct
+  path.  This is acceptable for typical transform+struct patterns (e.g. UTM
+  parsing) but will be slower than native `list.eval` for very large datasets.
+
+## `getItem` resolution outside schema context
+
+**Affected operations:** `col("arr").getItem(0)` used inside `filter()` or
+other contexts where `to_native()` is called before a schema is available.
+
+SparkleFrame stores `getItem` operations as a lazy chain (`_getitem_chain`)
+resolved during `to_native()`.  When `to_native()` runs outside a schema
+context (e.g. inside `isNotNull()` before `filter()` evaluates), the dtype
+resolver returns `None`, forcing a UDF fallback.
+
+The UDF fallbacks (`_extract_by_key`, `_index_at`) now handle `pl.Series`
+inputs correctly, but the resolution is less efficient than the native
+`list.get` / `struct.field` paths used when dtype is known.
+
+## `element_at` with `F.lit(int)` indices
+
+**Affected operations:** `element_at(col, F.lit(n))`, `try_element_at(col, F.lit(n))`
+
+`F.lit(value)` wraps the value in `pl.repeat(value, pl.len())`, which is a
+`pl.Expr` rather than a plain Python `int`.  SparkleFrame resolves this by
+evaluating the expression against a dummy DataFrame to extract the integer.
+This works but adds a small overhead per call.
+
+## `when/otherwise` with `F.lit(None)` type coercion
+
+**Affected operations:** `F.when(cond, expr).otherwise(F.lit(None))`
+
+PySpark infers the result type from the non-null branch; SparkleFrame now
+uses `pl.Null` dtype for `lit(None)`, which Polars correctly super-types with
+the non-null branch.  This is resolved for standard types but may still
+surface for complex nested types not yet tested.
+
+## Equality comparison dtype resolution
+
+**Affected operations:** `==`, `!=` between columns where both dtypes are
+unresolvable at expression build time.
+
+SparkleFrame includes a same-family short-circuit (both string, both numeric,
+or both boolean) that uses native Polars comparisons.  For cross-type
+comparisons (e.g. `col(int) == lit(string)`), the full coercion logic applies,
+which may use `map_batches` with a UDF.
+
 ## Map type detection
 
 **Affected operations:** all comparisons and arithmetic involving `MapType`

--- a/sparkleframe/polarsdf/column.py
+++ b/sparkleframe/polarsdf/column.py
@@ -223,24 +223,12 @@ class Column:
         return Column(~self.to_native())
 
     def __neg__(self):
-        """Unary minus (PySpark ``-col``), e.g. ``F.pow(1 + rate, -number_of_periods)`` when ``number_of_periods`` is a column."""
+        """Unary minus (PySpark ``-col``)."""
         return Column(-self.to_native())
 
     def __pos__(self):
         """Unary plus (PySpark ``+col``)."""
         return Column(+self.to_native())
-
-    def __neg__(self):
-        """Unary minus (PySpark ``-col``), e.g. ``F.pow(1 + rate, -number_of_periods)`` when ``number_of_periods`` is a column."""
-        c = Column(-self.to_native())
-        c._broadcast_row_count_in_select = bool(getattr(self, "_broadcast_row_count_in_select", False))
-        return c
-
-    def __pos__(self):
-        """Unary plus (PySpark ``+col``)."""
-        c = Column(+self.to_native())
-        c._broadcast_row_count_in_select = bool(getattr(self, "_broadcast_row_count_in_select", False))
-        return c
 
     def alias(self, name: str) -> Column:
         """

--- a/sparkleframe/polarsdf/column.py
+++ b/sparkleframe/polarsdf/column.py
@@ -32,9 +32,12 @@ class Column:
         *,
         getitem_chain: Tuple[Union[str, int], ...] = (),
         output_alias: Optional[str] = None,
+        struct_parts: Optional[list[pl.Expr]] = None,
     ):
         self._getitem_chain = getitem_chain
         self._output_alias = output_alias
+        self._struct_parts: Optional[list[pl.Expr]] = struct_parts
+        self._deferred_struct_transform: Optional[tuple] = None
         if isinstance(expr_or_name, str):
             self.expr = pl.col(expr_or_name)
         else:
@@ -278,8 +281,12 @@ class Column:
         ``"maybe".cast(boolean)``) instead of silently returning null. Use
         :meth:`try_cast` for the lenient variant that returns null.
 
-        Numeric / boolean coercions that Spark accepts (e.g. ``int -> bool`` via
-        nonzero -> true) still flow through Polars' native cast.
+        .. warning::
+
+           Polars evaluates **all** ``when/then/otherwise`` branches eagerly,
+           unlike PySpark which short-circuits.  A strict ``cast`` inside a
+           ``when`` branch will fail on rows that don't match the condition.
+           Use :meth:`try_cast` inside ``when/then`` branches instead.
 
         Args:
             data_type (DataType): A sparkleframe-defined DataType object.
@@ -291,12 +298,7 @@ class Column:
             raise TypeError(f"cast() expects a DataType, got {type(data_type)}")
         native = self.to_native()
         if isinstance(data_type, BooleanType):
-            # The helper dispatches at runtime: string source -> strict literal
-            # parse (CAST_INVALID_INPUT on unknown); numeric / bool source -> native
-            # Polars cast (which already matches Spark for those types).
             return Column(_string_to_bool_expr_strict(native))
-        # ``strict=True`` mirrors Spark 4 ANSI: Polars raises (wrapped) when any
-        # row fails the cast, where Spark raises ``CAST_INVALID_INPUT``.
         return Column(native.cast(data_type.to_native(), strict=True))
 
     def try_cast(self, data_type: Union[DataType, str]) -> "Column":

--- a/sparkleframe/polarsdf/column.py
+++ b/sparkleframe/polarsdf/column.py
@@ -230,6 +230,18 @@ class Column:
         """Unary plus (PySpark ``+col``)."""
         return Column(+self.to_native())
 
+    def __neg__(self):
+        """Unary minus (PySpark ``-col``), e.g. ``F.pow(1 + rate, -number_of_periods)`` when ``number_of_periods`` is a column."""
+        c = Column(-self.to_native())
+        c._broadcast_row_count_in_select = bool(getattr(self, "_broadcast_row_count_in_select", False))
+        return c
+
+    def __pos__(self):
+        """Unary plus (PySpark ``+col``)."""
+        c = Column(+self.to_native())
+        c._broadcast_row_count_in_select = bool(getattr(self, "_broadcast_row_count_in_select", False))
+        return c
+
     def alias(self, name: str) -> Column:
         """
         Mimics pyspark.sql.Column.alias

--- a/sparkleframe/polarsdf/column_helpers.py
+++ b/sparkleframe/polarsdf/column_helpers.py
@@ -437,9 +437,14 @@ def _validate_and_cast_float64_lenient(s: pl.Series) -> pl.Series:
 
 def _validated_arithmetic_expr(expr: pl.Expr, resolved_dt: Optional[pl.DataType]) -> pl.Expr:
     """
-    For +, -, *: validate if dtype is known at build time; otherwise embed a
-    runtime check via ``map_batches`` (without ``return_dtype`` so Polars keeps
-    the natural output type, e.g. ``Int32 + Int32`` stays ``Int32``).
+    For +, -, *: validate if dtype is known at build time; defer to runtime otherwise.
+
+    When the dtype is resolved, ``_assert_arithmetic_compatible`` rejects
+    non-numeric types immediately.  When it cannot be resolved (bare
+    ``pl.col("name")`` without a schema context), the expression is wrapped in
+    ``map_batches`` so that ``_assert_arithmetic_series`` validates the actual
+    Series dtype at evaluation time.  Polars can infer ``return_dtype`` from the
+    returned Series in eager context (SparkleFrame always evaluates eagerly).
     """
     if resolved_dt is not None:
         _assert_arithmetic_compatible(resolved_dt)
@@ -897,6 +902,12 @@ def _equality_comparison_expr(left: pl.Expr, right: pl.Expr, equal: bool) -> pl.
         return (left == right) if equal else (left != right)
     if _is_complex_polars_dtype(ld) or _is_complex_polars_dtype(rd):
         return (left == right) if equal else (left != right)
+    if ld is not None and rd is not None:
+        both_string = _is_string_polars_dtype(ld) and _is_string_polars_dtype(rd)
+        both_numeric = _is_numeric_polars_dtype(ld) and _is_numeric_polars_dtype(rd)
+        both_boolean = ld == pl.Boolean and rd == pl.Boolean
+        if both_string or both_numeric or both_boolean:
+            return (left == right) if equal else (left != right)
     left_num, right_num, left_str, right_str = _numeric_compare_operands(left, right)
     numeric_valid = left_num.is_not_null() & right_num.is_not_null()
     if equal:
@@ -937,38 +948,58 @@ def _apply_getitem_key(expr: pl.Expr, key: Union[str, int]) -> pl.Expr:
                     .list.first()
                 )
 
-        def _extract_by_key(value: Any) -> Any:
+        if dtype is None:
+            try:
+                refs = expr.meta.root_names()
+            except Exception:
+                refs = []
+            if not refs:
+                return expr.struct.field(key)
+
+        def _extract_by_key(value: Any) -> Optional[str]:
             if value is None:
                 return None
-            if isinstance(value, dict):
-                return value.get(key)
-            if isinstance(value, list):
+            raw: Any = None
+            if isinstance(value, pl.Series):
+                for row in value.to_list():
+                    if isinstance(row, dict) and row.get("key") == key:
+                        raw = row.get("value")
+                        break
+            elif isinstance(value, dict):
+                raw = value.get(key)
+            elif isinstance(value, list):
                 for entry in value:
                     if isinstance(entry, dict) and entry.get("key") == key:
-                        return entry.get("value")
-                return None
-            getter = getattr(value, "get", None)
-            if callable(getter):
-                try:
-                    return getter(key)
-                except Exception:
-                    return None
-            return None
+                        raw = entry.get("value")
+                        break
+            else:
+                getter = getattr(value, "get", None)
+                if callable(getter):
+                    try:
+                        raw = getter(key)
+                    except Exception:
+                        pass
+            return None if raw is None else str(raw)
 
-        return expr.map_elements(_extract_by_key, return_dtype=pl.Object)
+        return expr.map_elements(_extract_by_key, return_dtype=pl.String)
     if isinstance(key, int):
         dtype = _resolve_expr_output_dtype(expr)
         if isinstance(dtype, pl.List):
             return expr.list.get(key)
 
-        def _index_at(v: Any) -> Any:
+        def _index_at(v: Any) -> Optional[str]:
             if v is None:
                 return None
-            if isinstance(v, (list, tuple)):
-                if key < 0 or key >= len(v):
+            items: Any = v
+            if isinstance(v, pl.Series):
+                items = v.to_list()
+            if isinstance(items, (list, tuple)):
+                polars_idx = key
+                if polars_idx < 0 or polars_idx >= len(items):
                     return None
-                return v[key]
+                raw = items[polars_idx]
+                return None if raw is None else str(raw)
             return None
 
-        return expr.map_elements(_index_at, return_dtype=pl.Object)
+        return expr.map_elements(_index_at, return_dtype=pl.String)
     raise TypeError(f"getItem key must be str or int, got {type(key).__name__}")

--- a/sparkleframe/polarsdf/column_test.py
+++ b/sparkleframe/polarsdf/column_test.py
@@ -39,7 +39,7 @@ from sparkleframe.polarsdf.types import (
     ShortType,
     TimestampType,
 )
-from sparkleframe.tests.utils import assert_sparkle_spark_frame_are_equal
+from sparkleframe.tests.utils import assert_sparkle_spark_frame_are_equal, spark_rows_from_dict
 
 
 def _functions_pow_optional():
@@ -907,3 +907,25 @@ class TestCastParityWithSpark:
         spark_result = spark_df.select(F.col("s").cast(spark_dtype).alias("v"))
         sparkle_result = sparkle_df.select(col("s").cast(sparkle_dtype).alias("v"))
         assert_sparkle_spark_frame_are_equal(sparkle_result, spark_result)
+
+    def test_try_cast_inside_when_then_against_spark(self, spark):
+        """Polars evaluates all when/then branches eagerly, so strict cast fails on
+        non-matching rows.  Use try_cast inside when/then as a workaround; the result
+        matches PySpark's short-circuit cast behavior."""
+        from pyspark.sql.functions import when as spark_when
+
+        from sparkleframe.polarsdf.functions import when
+
+        data = {"v": ["1", "2", "N/A"]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+
+        sf_result = polars_df.withColumn(
+            "num",
+            when(col("v").rlike(r"^\d+$"), col("v").try_cast(IntegerType())).otherwise(lit(-1)),
+        )
+        sp_result = spark_df.withColumn(
+            "num",
+            spark_when(F.col("v").rlike(r"^\d+$"), F.col("v").cast(SparkIntegerType())).otherwise(F.lit(-1)),
+        )
+        assert_sparkle_spark_frame_are_equal(sf_result, sp_result)

--- a/sparkleframe/polarsdf/dataframe.py
+++ b/sparkleframe/polarsdf/dataframe.py
@@ -330,6 +330,7 @@ class DataFrame(BaseDataFrame):
         if hasattr(col, "branches") and hasattr(col, "otherwise"):
             col = col.otherwise(None)
         col = Column(col) if not isinstance(col, Column) else col
+
         if getattr(col, "_is_explode", False):
             source_name = getattr(col, "_explode_source_name", None)
             if source_name and source_name in self.df.columns:

--- a/sparkleframe/polarsdf/dataframe.py
+++ b/sparkleframe/polarsdf/dataframe.py
@@ -210,6 +210,53 @@ class DataFrame(BaseDataFrame):
 
     unionAll = union
 
+    def unionByName(self, other: "DataFrame", allowMissingColumns: bool = False) -> "DataFrame":
+        """
+        Mimics PySpark ``DataFrame.unionByName`` (UNION ALL by column name).
+
+        When ``allowMissingColumns`` is false, both frames must have the same set of
+        column names; the right side is reordered to match the left frame's column order.
+
+        When true, columns present in only one frame are filled with null in the other,
+        matching Spark's relaxed union-by-name.
+
+        Args:
+            other: Another sparkleframe :class:`DataFrame`.
+            allowMissingColumns: If true, allow disjoint schemas with null padding.
+
+        Returns:
+            DataFrame: Row-wise concatenation aligned by name.
+
+        Raises:
+            TypeError: If ``other`` is not a :class:`DataFrame`.
+            ValueError: If schemas differ and ``allowMissingColumns`` is false.
+        """
+        if not isinstance(other, DataFrame):
+            raise TypeError("unionByName() expects a DataFrame")
+
+        left_cols = self.columns
+        left_set = set(left_cols)
+        right_set = set(other.columns)
+
+        if not allowMissingColumns:
+            if left_set != right_set:
+                missing_in_right = sorted(left_set - right_set)
+                extra_in_right = sorted(right_set - left_set)
+                msg_parts: list[str] = []
+                if missing_in_right:
+                    msg_parts.append(f"columns not in the right frame: {missing_in_right}")
+                if extra_in_right:
+                    msg_parts.append(f"columns only in the right frame: {extra_in_right}")
+                raise ValueError(
+                    "unionByName() requires the same column names when allowMissingColumns=False ("
+                    + "; ".join(msg_parts)
+                    + "). Use allowMissingColumns=True to union with null padding."
+                )
+            right_aligned = other.df.select([pl.col(name) for name in left_cols])
+            return DataFrame(pl.concat([self.df, right_aligned], how="vertical"))
+
+        return DataFrame(pl.concat([self.df, other.df], how="diagonal_relaxed"))
+
     def distinct(self) -> "DataFrame":
         """
         Mimics PySpark's DataFrame.distinct.

--- a/sparkleframe/polarsdf/dataframe_test.py
+++ b/sparkleframe/polarsdf/dataframe_test.py
@@ -1342,3 +1342,28 @@ class TestDataFrame:
         )
 
         assert_pyspark_df_equal(result_spark_df, expected_spark_df, ignore_nullable=True)
+
+
+class TestUnionByName:
+    def test_aligns_by_column_name_not_position(self) -> None:
+        left = DataFrame(pl.DataFrame({"x": [1], "y": [2]}))
+        right = DataFrame(pl.DataFrame({"y": [3], "x": [4]}))
+        out = left.unionByName(right)
+        assert out.to_native_df().equals(pl.DataFrame({"x": [1, 4], "y": [2, 3]}))
+
+    def test_strict_rejects_disjoint_schemas(self) -> None:
+        left = DataFrame(pl.DataFrame({"x": [1], "y": [2]}))
+        right = DataFrame(pl.DataFrame({"x": [3], "z": [4]}))
+        with pytest.raises(ValueError, match="allowMissingColumns=True"):
+            left.unionByName(right, allowMissingColumns=False)
+
+    def test_allow_missing_columns_null_pads(self) -> None:
+        left = DataFrame(pl.DataFrame({"x": [1], "y": [2]}))
+        right = DataFrame(pl.DataFrame({"x": [5]}))
+        out = left.unionByName(right, allowMissingColumns=True)
+        assert out.to_native_df().equals(pl.DataFrame({"x": [1, 5], "y": [2, None]}))
+
+    def test_expects_dataframe(self) -> None:
+        left = DataFrame(pl.DataFrame({"x": [1]}))
+        with pytest.raises(TypeError, match="DataFrame"):
+            left.unionByName(pl.DataFrame({"x": [2]}))  # type: ignore[arg-type]

--- a/sparkleframe/polarsdf/dataframe_test.py
+++ b/sparkleframe/polarsdf/dataframe_test.py
@@ -1367,3 +1367,25 @@ class TestUnionByName:
         left = DataFrame(pl.DataFrame({"x": [1]}))
         with pytest.raises(TypeError, match="DataFrame"):
             left.unionByName(pl.DataFrame({"x": [2]}))  # type: ignore[arg-type]
+
+    def test_union_by_name_against_spark(self, spark) -> None:
+        left_data = {"x": [1, 2], "y": [10, 20]}
+        right_data = {"y": [30, 40], "x": [3, 4]}
+        sf_left = DataFrame(pl.DataFrame(left_data))
+        sf_right = DataFrame(pl.DataFrame(right_data))
+        sf_result = sf_left.unionByName(sf_right)
+        sp_left = spark.createDataFrame(pd.DataFrame(left_data))
+        sp_right = spark.createDataFrame(pd.DataFrame(right_data))
+        sp_result = sp_left.unionByName(sp_right)
+        assert_sparkle_spark_frame_are_equal(sf_result, sp_result)
+
+    def test_union_by_name_allow_missing_against_spark(self, spark) -> None:
+        left_data = {"x": [1], "y": [2]}
+        right_data = {"x": [3], "z": [4]}
+        sf_left = DataFrame(pl.DataFrame(left_data))
+        sf_right = DataFrame(pl.DataFrame(right_data))
+        sf_result = sf_left.unionByName(sf_right, allowMissingColumns=True)
+        sp_left = spark.createDataFrame(pd.DataFrame(left_data))
+        sp_right = spark.createDataFrame(pd.DataFrame(right_data))
+        sp_result = sp_left.unionByName(sp_right, allowMissingColumns=True)
+        assert_sparkle_spark_frame_are_equal(sf_result, sp_result)

--- a/sparkleframe/polarsdf/functions.py
+++ b/sparkleframe/polarsdf/functions.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import random
 from datetime import date
 from typing import Any, Callable, Optional, Union
 from uuid import uuid4
@@ -14,14 +13,18 @@ from sparkleframe.polarsdf.column_helpers import _output_dtype_of_expr, _polars_
 from sparkleframe.polarsdf.functions_helpers import (
     _as_date_sparklike_expr,
     _coerce_json_value,
+    _convert_spark_datetime_pattern_to_strftime,
     _md5_sparklike,
     _now_batch,
+    _rand_batch,
     _RankWrapper,
     _re_split_sparklike,
     _schema_from_string,
+    _size_sparklike_value,
     _substring_sparklike,
     _to_date_column,
     _to_datetime_column,
+    _to_json_batch,
     _to_timestamp_no_format_column,
     element_at_column,
 )
@@ -97,56 +100,6 @@ def from_json(col_name: Union[str, Column], schema: Union[DataType, str]) -> Col
     else:
         return_dtype = parsed_schema
     return Column(expr.map_elements(_parse, return_dtype=return_dtype))
-
-
-def _map_entries_list_to_json_obj(entries: Any) -> str | None:
-    if entries is None:
-        return None
-    if not isinstance(entries, list):
-        return None
-    out: dict[str, Any] = {}
-    for e in entries:
-        if not isinstance(e, dict):
-            continue
-        k = e.get("key")
-        if k is None:
-            continue
-        out[str(k)] = e.get("value")
-    return json.dumps(out, separators=(",", ":"))
-
-
-def _is_spark_map_entry_list_dtype(list_dtype: pl.List) -> bool:
-    inner = list_dtype.inner
-    if not isinstance(inner, pl.Struct):
-        return False
-    names = {f.name for f in inner.fields}
-    return names == {"key", "value"}
-
-
-def _to_json_batch(s: pl.Series) -> pl.Series:
-    name = s.name
-    if s.len() == 0:
-        return pl.Series(name, [], dtype=pl.String)
-    dt = s.dtype
-    if isinstance(dt, pl.Struct):
-        return s.struct.json_encode()
-    if isinstance(dt, pl.List):
-        if _is_spark_map_entry_list_dtype(dt):
-            rows = s.to_list()
-            encoded = [_map_entries_list_to_json_obj(x) for x in rows]
-            return pl.Series(name, encoded, dtype=pl.String)
-        rows = s.to_list()
-
-        def _dump(v: Any) -> str | None:
-            if v is None:
-                return None
-            return json.dumps(v, separators=(",", ":"), default=str)
-
-        return pl.Series(name, [_dump(x) for x in rows], dtype=pl.String)
-    raise TypeError(
-        "to_json expects a struct column, an array column, or a sparkleframe map column "
-        f"(list<struct<key,value>>); got {dt}"
-    )
 
 
 def to_json(col_name: Union[str, Column], options: Any = None) -> Column:
@@ -817,7 +770,7 @@ def floor(col_name: Union[str, Column]) -> Column:
         Column: Floored values (``Float64`` after rounding when the input was fractional).
     """
     expr = _to_expr(col_name) if isinstance(col_name, Column) else pl.col(col_name)
-    return Column(expr.cast(pl.Float64, strict=False).floor())
+    return Column(expr.cast(pl.Float64, strict=False).floor().cast(pl.Int64))
 
 
 def pow(base: Any, exponent: Any) -> Column:
@@ -926,7 +879,6 @@ def nullif(e1: Union[str, Column], e2: Union[str, Column]) -> Column:
     a = _to_expr(e1) if isinstance(e1, Column) else pl.col(e1)
     b = _to_expr(e2) if isinstance(e2, Column) else pl.col(e2)
     return Column(pl.when(a.is_not_null() & b.is_not_null() & (a == b)).then(None).otherwise(a))
-
 
 
 def split(col_name: Union[str, Column], pattern: str, limit: int = -1) -> Column:
@@ -1038,14 +990,6 @@ def months_between(end: Union[str, Column], start: Union[str, Column]) -> Column
     return Column((whole_months + day_fraction).cast(pl.Float64))
 
 
-def _rand_batch(s: pl.Series, seed: Optional[int]) -> pl.Series:
-    n = s.len()
-    if n == 0:
-        return pl.Series(s.name, [], dtype=pl.Float64)
-    rng = random.Random(seed) if seed is not None else random.Random()
-    return pl.Series(s.name, [rng.random() for _ in range(n)], dtype=pl.Float64)
-
-
 def rand(seed: Optional[int] = None) -> Column:
     """
     Mimics pyspark.sql.functions.rand: uniform random in ``[0.0, 1.0)`` per row.
@@ -1064,7 +1008,6 @@ def rand(seed: Optional[int] = None) -> Column:
             return_dtype=pl.Float64,
         )
     )
-
 
 
 def broadcast(df: Any) -> Any:
@@ -1100,19 +1043,6 @@ def array_contains(col_name: Union[str, Column], value: Union[str, Column, Any])
     array_expr = _to_expr(col_name) if isinstance(col_name, Column) else pl.col(col_name)
     value_expr = _to_expr(value) if isinstance(value, Column) else pl.lit(value)
     return Column(array_expr.list.contains(value_expr))
-
-
-def _size_sparklike_value(v: Any) -> int | None:
-    """Row-wise length for Spark-like ``size`` when Polars dtype is not ``List`` (e.g. ``Object``)."""
-    if v is None:
-        return None
-    if isinstance(v, pl.Series):
-        return v.len()
-    if isinstance(v, list):
-        return len(v)
-    if isinstance(v, dict):
-        return len(v)
-    return None
 
 
 def size(col_name: Union[str, Column]) -> Column:

--- a/sparkleframe/polarsdf/functions.py
+++ b/sparkleframe/polarsdf/functions.py
@@ -224,6 +224,9 @@ def count(col_name: Union[str, Column]) -> Column:
     Mimics pyspark.sql.functions.count.
 
     Counts the number of non-null elements for the specified column.
+    When ``col_name`` is ``"*"``, returns the total row count (like SQL ``COUNT(*)``),
+    using ``pl.len()`` instead of ``pl.col("*").count()`` to avoid Polars expanding
+    ``"*"`` into every column and producing duplicates.
 
     Args:
         col_name (str or Column): The column to count non-null values in.
@@ -231,6 +234,8 @@ def count(col_name: Union[str, Column]) -> Column:
     Returns:
         Column: A Column representing the count aggregation expression.
     """
+    if isinstance(col_name, str) and col_name == "*":
+        return Column(pl.len())
     expr = _to_expr(col_name) if isinstance(col_name, Column) else pl.col(col_name)
     return Column(expr.count())
 

--- a/sparkleframe/polarsdf/functions.py
+++ b/sparkleframe/polarsdf/functions.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import random
 from datetime import date
 from typing import Any, Callable, Optional, Union
 from uuid import uuid4
@@ -9,6 +10,7 @@ import polars as pl
 
 from sparkleframe.polarsdf import WindowSpec
 from sparkleframe.polarsdf.column import Column, _to_expr
+from sparkleframe.polarsdf.column_helpers import _output_dtype_of_expr, _polars_schema_ctx
 from sparkleframe.polarsdf.functions_helpers import (
     _as_date_sparklike_expr,
     _coerce_json_value,
@@ -97,6 +99,71 @@ def from_json(col_name: Union[str, Column], schema: Union[DataType, str]) -> Col
     return Column(expr.map_elements(_parse, return_dtype=return_dtype))
 
 
+def _map_entries_list_to_json_obj(entries: Any) -> str | None:
+    if entries is None:
+        return None
+    if not isinstance(entries, list):
+        return None
+    out: dict[str, Any] = {}
+    for e in entries:
+        if not isinstance(e, dict):
+            continue
+        k = e.get("key")
+        if k is None:
+            continue
+        out[str(k)] = e.get("value")
+    return json.dumps(out, separators=(",", ":"))
+
+
+def _is_spark_map_entry_list_dtype(list_dtype: pl.List) -> bool:
+    inner = list_dtype.inner
+    if not isinstance(inner, pl.Struct):
+        return False
+    names = {f.name for f in inner.fields}
+    return names == {"key", "value"}
+
+
+def _to_json_batch(s: pl.Series) -> pl.Series:
+    name = s.name
+    if s.len() == 0:
+        return pl.Series(name, [], dtype=pl.String)
+    dt = s.dtype
+    if isinstance(dt, pl.Struct):
+        return s.struct.json_encode()
+    if isinstance(dt, pl.List):
+        if _is_spark_map_entry_list_dtype(dt):
+            rows = s.to_list()
+            encoded = [_map_entries_list_to_json_obj(x) for x in rows]
+            return pl.Series(name, encoded, dtype=pl.String)
+        rows = s.to_list()
+
+        def _dump(v: Any) -> str | None:
+            if v is None:
+                return None
+            return json.dumps(v, separators=(",", ":"), default=str)
+
+        return pl.Series(name, [_dump(x) for x in rows], dtype=pl.String)
+    raise TypeError(
+        "to_json expects a struct column, an array column, or a sparkleframe map column "
+        f"(list<struct<key,value>>); got {dt}"
+    )
+
+
+def to_json(col_name: Union[str, Column], options: Any = None) -> Column:
+    """
+    Mimics pyspark.sql.functions.to_json for struct, array, and map-like columns.
+
+    Map columns produced by :func:`create_map` / :func:`map_from_entries` (encoded as
+    ``list<struct<key,value>>``) are serialized as JSON objects, like Spark ``MapType``.
+
+    Supports only ``options={"ignoreNullFields": False}`` from Spark's options map.
+    """
+    if options is not None and options != {"ignoreNullFields": False}:
+        raise ValueError('sparkleframe to_json only supports options={"ignoreNullFields": False}')
+    expr = _to_expr(col_name) if isinstance(col_name, Column) else pl.col(col_name)
+    return Column(expr.map_batches(_to_json_batch, return_dtype=pl.String))
+
+
 def lit(value) -> Column:
     """
     Mimics pyspark.sql.functions.lit.
@@ -139,6 +206,64 @@ def coalesce(*cols: Union[str, Column]) -> Column:
     expressions = [_to_expr(col) if isinstance(col, Column) else pl.col(col) for col in cols]
 
     return Column(pl.coalesce(*expressions))
+
+
+def least(*cols: Any) -> Column:
+    """
+    Mimics pyspark.sql.functions.least.
+
+    Returns the smallest value per row across the given columns or literals. Null
+    inputs are skipped; the result is null when every argument is null for that row.
+
+    Note:
+        Spark also skips IEEE-754 ``NaN`` in floating-point ``least``; Polars
+        ``min_horizontal`` may return ``NaN`` when any argument is ``NaN``. Prefer
+        nulls for missing floats, or normalize ``NaN`` before calling :func:`least`,
+        if you need Spark-identical behaviour on ``NaN``.
+
+    Args:
+        *cols: Column names (``str``), :class:`~sparkleframe.polarsdf.column.Column`
+            expressions, literals, or ``pl.Expr``.
+
+    Returns:
+        Column: Row-wise minimum in the promoted common type.
+
+    Raises:
+        ValueError: If fewer than two arguments are provided.
+    """
+    if len(cols) < 2:
+        raise ValueError("least requires at least two arguments")
+    expressions: list[pl.Expr] = [pl.col(c) if isinstance(c, str) else _to_expr(c) for c in cols]
+    return Column(pl.min_horizontal(*expressions))
+
+
+def greatest(*cols: Any) -> Column:
+    """
+    Mimics pyspark.sql.functions.greatest.
+
+    Returns the largest value per row across the given columns or literals. Null
+    inputs are skipped; the result is null when every argument is null for that row.
+
+    Note:
+        Spark skips IEEE-754 ``NaN`` in floating-point ``greatest``; Polars
+        ``max_horizontal`` may return ``NaN`` when any argument is ``NaN``. Prefer
+        nulls for missing floats, or normalize ``NaN`` before calling :func:`greatest`,
+        if you need Spark-identical behaviour on ``NaN``.
+
+    Args:
+        *cols: Column names (``str``), :class:`~sparkleframe.polarsdf.column.Column`
+            expressions, literals, or ``pl.Expr``.
+
+    Returns:
+        Column: Row-wise maximum in the promoted common type.
+
+    Raises:
+        ValueError: If fewer than two arguments are provided.
+    """
+    if len(cols) < 2:
+        raise ValueError("greatest requires at least two arguments")
+    expressions: list[pl.Expr] = [pl.col(c) if isinstance(c, str) else _to_expr(c) for c in cols]
+    return Column(pl.max_horizontal(*expressions))
 
 
 def count(col_name: Union[str, Column]) -> Column:
@@ -249,6 +374,59 @@ def map_from_entries(col_name: Union[str, Column]) -> Column:
         return None
 
     return Column(expr.map_elements(_entries_to_map, return_dtype=pl.Object))
+
+
+def create_map(*cols: Any) -> Column:
+    """
+    Mimics pyspark.sql.functions.create_map.
+
+    Builds a map column from alternating key and value arguments. Keys and values may
+    be column names (``str``), :class:`~sparkleframe.polarsdf.column.Column` expressions,
+    or literals. The result uses sparkleframe's map encoding (``list<struct<key,value>>``),
+    consistent with :func:`map_from_entries` and map helpers.
+
+    Args:
+        *cols: Even-length sequence ``k1, v1, k2, v2, ...``.
+
+    Returns:
+        Column: One map per row.
+
+    Raises:
+        ValueError: If the number of arguments is odd.
+    """
+    if len(cols) % 2 != 0:
+        raise ValueError("create_map requires an even number of arguments (key, value pairs)")
+    if not cols:
+        empty_dtype = pl.List(
+            pl.Struct([pl.Field("key", pl.String), pl.Field("value", pl.String)]),
+        )
+        return Column(pl.lit([], dtype=empty_dtype))
+    parts: list[pl.Expr] = []
+    for i in range(0, len(cols), 2):
+        key_expr = pl.col(cols[i]) if isinstance(cols[i], str) else _to_expr(cols[i])
+        val_expr = pl.col(cols[i + 1]) if isinstance(cols[i + 1], str) else _to_expr(cols[i + 1])
+        parts.append(pl.struct([key_expr.alias("key"), val_expr.alias("value")]))
+    return Column(pl.concat_list(parts))
+
+
+def array(*cols: Any) -> Column:
+    """
+    Mimics pyspark.sql.functions.array.
+
+    Builds a list column from column names (``str``), :class:`~sparkleframe.polarsdf.column.Column`
+    values, or literals. Spark requires a common element type; Polars may infer a supertype or
+    object list when mixing incompatible types.
+
+    Args:
+        *cols: Zero or more arguments (empty ``array()`` yields an empty list column).
+
+    Returns:
+        Column: One list value per row.
+    """
+    if not cols:
+        return Column(pl.lit([], dtype=pl.List(pl.Null)))
+    parts: list[pl.Expr] = [pl.col(c) if isinstance(c, str) else _to_expr(c) for c in cols]
+    return Column(pl.concat_list(parts))
 
 
 def map_keys(col_name: Union[str, Column]) -> Column:
@@ -373,6 +551,27 @@ def to_timestamp(
     if fmt is None:
         return _to_timestamp_no_format_column(col_name, strict=True)
     return _to_datetime_column(col_name, fmt, strict=True)
+
+
+def date_format(col_name: Union[str, Column], fmt: str) -> Column:
+    """
+    Mimics pyspark.sql.functions.date_format.
+
+    Formats date or timestamp values as strings using Spark datetime pattern letters
+    (``yyyy``, ``MM``, ``dd``, ``HH``, ``mm``, ``ss``). Inputs are cast to microsecond
+    timestamps like Spark; :class:`date` values use midnight for time-of-day fields.
+
+    Args:
+        col_name (str or Column): Temporal column (or values castable to timestamp).
+        fmt (str): Spark datetime pattern.
+
+    Returns:
+        Column: Utf8 formatted strings; null when the input is null.
+    """
+    strftime_fmt = _convert_spark_datetime_pattern_to_strftime(fmt)
+    expr = _to_expr(col_name) if isinstance(col_name, Column) else pl.col(col_name)
+    dt_expr = expr.cast(pl.Datetime("us"), strict=False)
+    return Column(dt_expr.dt.strftime(strftime_fmt))
 
 
 def regexp_replace(col_name: Union[str, Column], pattern: str, replacement: str) -> Column:
@@ -604,6 +803,71 @@ def abs(col_name: Union[str, Column]) -> Column:
     return Column(expr.abs())
 
 
+def floor(col_name: Union[str, Column]) -> Column:
+    """
+    Mimics pyspark.sql.functions.floor.
+
+    Rounds numeric values down to the nearest integer. Non-numeric strings follow
+    Spark-like casting via ``cast(..., strict=False)`` before ``floor``.
+
+    Args:
+        col_name (str or Column): Numeric or string-castable column.
+
+    Returns:
+        Column: Floored values (``Float64`` after rounding when the input was fractional).
+    """
+    expr = _to_expr(col_name) if isinstance(col_name, Column) else pl.col(col_name)
+    return Column(expr.cast(pl.Float64, strict=False).floor())
+
+
+def pow(base: Any, exponent: Any) -> Column:
+    """
+    Mimics pyspark.sql.functions.pow (``base`` ** ``exponent``).
+
+    Both sides may be column names (``str``), :class:`~sparkleframe.polarsdf.column.Column`,
+    ``pl.Expr``, or scalar literals (e.g. ``F.pow(1 + col('rate'), -36)``).
+
+    Args:
+        base: Base expression or column name.
+        exponent: Exponent expression, column name, or scalar.
+
+    Returns:
+        Column: ``base ** exponent``; null if either operand is null.
+    """
+    base_expr = pl.col(base) if isinstance(base, str) else _to_expr(base)
+    exp_expr = pl.col(exponent) if isinstance(exponent, str) else _to_expr(exponent)
+    return Column(base_expr.pow(exp_expr))
+
+
+def isnan(col_name: Union[str, Column]) -> Column:
+    """
+    Mimics pyspark.sql.functions.isnan.
+
+    Returns false for null inputs (Spark behaviour). Non-float values are evaluated
+    after casting to ``Float64`` with ``strict=False``; values that cannot be cast
+    yield false here, whereas Spark with ANSI enabled may fail the stage on invalid casts.
+    """
+    expr = _to_expr(col_name) if isinstance(col_name, Column) else pl.col(col_name)
+    as_float = expr.cast(pl.Float64, strict=False)
+    return Column(
+        pl.when(expr.is_null()).then(pl.lit(False)).otherwise(as_float.is_nan().fill_null(False)).cast(pl.Boolean)
+    )
+
+
+def try_divide(left: Union[str, Column], right: Union[str, Column]) -> Column:
+    """
+    Mimics pyspark.sql.functions.try_divide (Spark 3.4+).
+
+    Returns null when the divisor is zero or null, or when the dividend is null.
+    Otherwise returns ``left / right`` as ``Float64``.
+    """
+    l_expr = _to_expr(left) if isinstance(left, Column) else pl.col(left)
+    r_expr = _to_expr(right) if isinstance(right, Column) else pl.col(right)
+    l64 = l_expr.cast(pl.Float64, strict=False)
+    r64 = r_expr.cast(pl.Float64, strict=False)
+    return Column(pl.when(l_expr.is_null() | r_expr.is_null() | (r64 == 0)).then(pl.lit(None)).otherwise(l64 / r64))
+
+
 def lower(col_name: Union[str, Column]) -> Column:
     """
     Mimics pyspark.sql.functions.lower.
@@ -649,6 +913,20 @@ def trim(col_name: Union[str, Column]) -> Column:
     """
     expr = _to_expr(col_name) if isinstance(col_name, Column) else pl.col(col_name)
     return Column(expr.str.strip_chars(" "))
+
+
+def nullif(e1: Union[str, Column], e2: Union[str, Column]) -> Column:
+    """
+    Mimics pyspark.sql.functions.nullif.
+
+    Returns null when both operands are non-null and equal; otherwise returns ``e1``.
+    Matches Spark ``CASE WHEN e1 = e2 THEN NULL ELSE e1 END`` (equality unknown when
+    either side is null yields ``e1``).
+    """
+    a = _to_expr(e1) if isinstance(e1, Column) else pl.col(e1)
+    b = _to_expr(e2) if isinstance(e2, Column) else pl.col(e2)
+    return Column(pl.when(a.is_not_null() & b.is_not_null() & (a == b)).then(None).otherwise(a))
+
 
 
 def split(col_name: Union[str, Column], pattern: str, limit: int = -1) -> Column:
@@ -707,6 +985,16 @@ def monotonically_increasing_id() -> Column:
     return Column(pl.int_range(0, pl.len(), dtype=pl.Int64, eager=False))
 
 
+def current_timestamp() -> Column:
+    """
+    Mimics pyspark.sql.functions.current_timestamp.
+
+    Same semantics as :func:`now` in sparkleframe: one UTC wall-clock timestamp shared by
+    all rows in the batch at evaluation (microsecond precision, no tzinfo).
+    """
+    return now()
+
+
 def current_date() -> Column:
     """Mimics pyspark.sql.functions.current_date."""
     return Column(pl.lit(date.today()))
@@ -750,6 +1038,35 @@ def months_between(end: Union[str, Column], start: Union[str, Column]) -> Column
     return Column((whole_months + day_fraction).cast(pl.Float64))
 
 
+def _rand_batch(s: pl.Series, seed: Optional[int]) -> pl.Series:
+    n = s.len()
+    if n == 0:
+        return pl.Series(s.name, [], dtype=pl.Float64)
+    rng = random.Random(seed) if seed is not None else random.Random()
+    return pl.Series(s.name, [rng.random() for _ in range(n)], dtype=pl.Float64)
+
+
+def rand(seed: Optional[int] = None) -> Column:
+    """
+    Mimics pyspark.sql.functions.rand: uniform random in ``[0.0, 1.0)`` per row.
+
+    Without ``seed``, each evaluation uses an independent :class:`random.Random` instance
+    (system-entropy seed). With ``seed``, draws are deterministic for a given row count within
+    one process; values do not match Spark's JVM PRNG for the same seed.
+    """
+
+    def _batch(series: pl.Series) -> pl.Series:
+        return _rand_batch(series, seed)
+
+    return Column(
+        pl.int_range(0, pl.len(), dtype=pl.Int64, eager=False).map_batches(
+            _batch,
+            return_dtype=pl.Float64,
+        )
+    )
+
+
+
 def broadcast(df: Any) -> Any:
     """
     Mimics pyspark.sql.functions.broadcast.
@@ -759,6 +1076,25 @@ def broadcast(df: Any) -> Any:
     return df
 
 
+def sort_array(col_name: Union[str, Column], asc: bool = True) -> Column:
+    """
+    Mimics pyspark.sql.functions.sort_array.
+
+    Sorts each array in the column in ascending or descending order. Null arrays stay
+    null; empty arrays stay empty.
+
+    Args:
+        col_name (str or Column): Array column.
+        asc (bool): If true (default), sort ascending; if false, descending. PySpark 4's
+            Python ``sort_array`` expects a boolean here (not a ``Column``).
+
+    Returns:
+        Column: Array column of sorted lists.
+    """
+    expr = _to_expr(col_name) if isinstance(col_name, Column) else pl.col(col_name)
+    return Column(expr.list.sort(descending=not asc))
+
+
 def array_contains(col_name: Union[str, Column], value: Union[str, Column, Any]) -> Column:
     """Mimics pyspark.sql.functions.array_contains."""
     array_expr = _to_expr(col_name) if isinstance(col_name, Column) else pl.col(col_name)
@@ -766,10 +1102,44 @@ def array_contains(col_name: Union[str, Column], value: Union[str, Column, Any])
     return Column(array_expr.list.contains(value_expr))
 
 
+def _size_sparklike_value(v: Any) -> int | None:
+    """Row-wise length for Spark-like ``size`` when Polars dtype is not ``List`` (e.g. ``Object``)."""
+    if v is None:
+        return None
+    if isinstance(v, pl.Series):
+        return v.len()
+    if isinstance(v, list):
+        return len(v)
+    if isinstance(v, dict):
+        return len(v)
+    return None
+
+
 def size(col_name: Union[str, Column]) -> Column:
-    """Mimics pyspark.sql.functions.size for array/map-like values."""
+    """
+    Mimics pyspark.sql.functions.size for array/map-like values.
+
+    Uses native ``list.len`` when the column resolves to a Polars ``List`` dtype (including
+    under an active frame schema in :meth:`DataFrame.select` / :meth:`DataFrame.filter`).
+    For ``Object`` columns that store Python ``list``/``dict`` cells — common for nested
+    struct fields built from semi-structured data — falls back to a row-wise length so
+    Spark-style ``size`` on dotted struct paths matches Spark behaviour instead of raising
+    Polars' \"expected List data type for list operation, got: Object\".
+    """
     expr = _to_expr(col_name) if isinstance(col_name, Column) else pl.col(col_name)
-    return Column(pl.when(expr.is_null()).then(pl.lit(None)).otherwise(expr.list.len()).cast(pl.Int32))
+    sch = _polars_schema_ctx.get()
+    use_list_fastpath = False
+    if sch is not None:
+        dt = _output_dtype_of_expr(expr, sch)
+        if isinstance(dt, pl.List):
+            use_list_fastpath = True
+    if use_list_fastpath:
+        return Column(pl.when(expr.is_null()).then(pl.lit(None)).otherwise(expr.list.len()).cast(pl.Int32))
+    return Column(
+        pl.when(expr.is_null())
+        .then(pl.lit(None))
+        .otherwise(expr.map_elements(_size_sparklike_value, return_dtype=pl.Int32))
+    )
 
 
 def filter(col_name: Union[str, Column], func: Callable[[Column], Any]) -> Column:

--- a/sparkleframe/polarsdf/functions.py
+++ b/sparkleframe/polarsdf/functions.py
@@ -14,6 +14,7 @@ from sparkleframe.polarsdf.functions_helpers import (
     _as_date_sparklike_expr,
     _coerce_json_value,
     _convert_spark_datetime_pattern_to_strftime,
+    _infer_struct_return_dtype_from_expr,
     _md5_sparklike,
     _now_batch,
     _rand_batch,
@@ -21,11 +22,14 @@ from sparkleframe.polarsdf.functions_helpers import (
     _re_split_sparklike,
     _schema_from_string,
     _size_sparklike_value,
+    _struct_return_dtype_from_parts,
     _substring_sparklike,
     _to_date_column,
     _to_datetime_column,
     _to_json_batch,
     _to_timestamp_no_format_column,
+    _transform_produces_struct,
+    _transform_struct_batch,
     element_at_column,
 )
 from sparkleframe.polarsdf.types import DataType
@@ -136,8 +140,11 @@ def lit(value) -> Column:
         Column: A Column object wrapping a literal Polars expression.
     """
     if value is None:
-        # Spark ``lit(None)`` has ``StringType`` by default; mirror that.
-        return Column(pl.repeat(None, pl.len(), dtype=pl.String))
+        # Use ``pl.Null`` so Polars infers the type from sibling branches in
+        # ``when/then/otherwise`` instead of forcing ``String``.  PySpark's
+        # ``lit(None)`` defaults to ``StringType`` when used standalone, but
+        # inside a conditional it adopts the type of the non-null branch.
+        return Column(pl.repeat(None, pl.len(), dtype=pl.Null))
     return Column(pl.repeat(value, pl.len()))
 
 
@@ -315,23 +322,13 @@ def map_from_entries(col_name: Union[str, Column]) -> Column:
     Mimics pyspark.sql.functions.map_from_entries.
 
     Expects an array of structs with ``key`` and ``value`` fields.
+    Spark maps are represented as ``List(Struct(key, value))`` so that
+    ``element_at`` / ``getItem`` map-by-key lookup works natively.
+
+    The input types are preserved; no forced cast to String is applied.
     """
     expr = _to_expr(col_name) if isinstance(col_name, Column) else pl.col(col_name)
-
-    def _entries_to_map(value: Any) -> Any:
-        if value is None:
-            return None
-        if isinstance(value, dict):
-            return value
-        if isinstance(value, list):
-            out: dict[Any, Any] = {}
-            for entry in value:
-                if isinstance(entry, dict) and "key" in entry and "value" in entry:
-                    out[entry["key"]] = entry["value"]
-            return out
-        return None
-
-    return Column(expr.map_elements(_entries_to_map, return_dtype=pl.Object))
+    return Column(expr)
 
 
 def create_map(*cols: Any) -> Column:
@@ -436,11 +433,21 @@ def transform(col_name: Union[str, Column], func: Callable[[Column], Any]) -> Co
     Mimics pyspark.sql.functions.transform for array columns.
 
     Applies a lambda expression to each element of an array and returns a new array.
+
+    When the lambda produces a struct (``pl.struct`` inside ``list.eval`` is unsupported
+    by Polars), falls back to a Python-side row-wise approach via ``map_batches``.
     """
     expr = _to_expr(col_name) if isinstance(col_name, Column) else pl.col(col_name)
     element_col = Column(pl.element())
     transformed = func(element_col)
     transformed_expr = transformed.to_native() if isinstance(transformed, Column) else _to_expr(transformed)
+
+    if _transform_produces_struct(transformed_expr):
+        if isinstance(transformed, Column) and transformed._struct_parts is not None:
+            return_dtype = _struct_return_dtype_from_parts(transformed._struct_parts)
+        else:
+            return_dtype = _infer_struct_return_dtype_from_expr(transformed_expr)
+        return Column(expr.map_batches(lambda s: _transform_struct_batch(s, func), return_dtype=return_dtype))
     return Column(expr.list.eval(transformed_expr))
 
 
@@ -464,17 +471,22 @@ def round(col_name: Union[str, Column], scale: int = 0) -> Column:
 class WhenBuilder:
     def __init__(self, condition: Column, value):
         self.branches = [(condition.to_native(), _to_expr(value))]
+        self._struct_parts: Optional[list[pl.Expr]] = None
+        if isinstance(value, Column) and value._struct_parts is not None:
+            self._struct_parts = value._struct_parts
 
     def when(self, condition: Any, value) -> "WhenBuilder":
         condition = Column(condition) if not isinstance(condition, Column) else condition
         self.branches.append((condition.to_native(), _to_expr(value)))
+        if self._struct_parts is None and isinstance(value, Column) and value._struct_parts is not None:
+            self._struct_parts = value._struct_parts
         return self
 
     def otherwise(self, value) -> Column:
         expr = pl.when(self.branches[0][0]).then(self.branches[0][1])
         for cond, val in self.branches[1:]:
             expr = expr.when(cond).then(val)
-        return Column(expr.otherwise(_to_expr(value)))
+        return Column(expr.otherwise(_to_expr(value)), struct_parts=self._struct_parts)
 
 
 def when(condition: Any, value) -> WhenBuilder:
@@ -1136,16 +1148,23 @@ def _struct_child_field_name(arg: Union[str, Column], expr: pl.Expr, index: int)
         # without ``cloudpickle`` installed. Such expressions are never plain
         # broadcast literals, so fall through to the regular naming rules.
         pass
-    undone = expr.meta.undo_aliases()
-    # Explicit Alias (nested struct(...).alias("nested_x"), col().alias("z"), …): Spark uses output_name.
-    # Do not use serialize() inequality — Polars versions disagree for bare struct(); compare output names instead.
-    if expr.meta.output_name() != undone.meta.output_name():
-        return expr.meta.output_name().split(".")[-1]
-    # Alias-of-column (e.g. col("a").alias("z")) is not is_column() in Polars; Spark uses the alias name.
-    if undone.meta.is_column():
-        return expr.meta.output_name().split(".")[-1]
-    if expr.meta.is_literal():
-        return f"col{index + 1}"
+    try:
+        undone = expr.meta.undo_aliases()
+        # Explicit Alias (nested struct(...).alias("nested_x"), col().alias("z"), …): Spark uses output_name.
+        # Do not use serialize() inequality — Polars versions disagree for bare struct(); compare output names instead.
+        if expr.meta.output_name() != undone.meta.output_name():
+            return expr.meta.output_name().split(".")[-1]
+        # Alias-of-column (e.g. col("a").alias("z")) is not is_column() in Polars; Spark uses the alias name.
+        if undone.meta.is_column():
+            return expr.meta.output_name().split(".")[-1]
+        if expr.meta.is_literal():
+            return f"col{index + 1}"
+    except Exception:
+        # Expressions derived from ``pl.element()`` (inside ``transform`` lambdas)
+        # have no root column name, so ``output_name()`` raises.  Fall back to the
+        # alias set on the Column wrapper if available.
+        if isinstance(arg, Column) and arg._output_alias is not None:
+            return arg._output_alias
     return f"col{index + 1}"
 
 
@@ -1175,7 +1194,7 @@ def struct(*cols: Any) -> Column:
     if not expanded:
         raise ValueError("struct requires at least one column")
     parts = [_struct_named_child(c, i) for i, c in enumerate(expanded)]
-    return Column(pl.struct(parts))
+    return Column(pl.struct(parts), struct_parts=parts)
 
 
 def try_to_timestamp(

--- a/sparkleframe/polarsdf/functions_helpers.py
+++ b/sparkleframe/polarsdf/functions_helpers.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import hashlib
+import json
+import random
 import re
 from datetime import datetime, timezone
 from typing import Any, Optional, Union
@@ -100,6 +102,24 @@ def _convert_spark_ts_format(fmt: str) -> str:
     for spark_fmt, strftime_fmt in _SPARK_TS_FORMAT_MAP:
         fmt = fmt.replace(spark_fmt, strftime_fmt)
     return fmt
+
+
+_SPARK_DATETIME_STRFTIME_MAP = [
+    ("yyyy", "%Y"),
+    ("MM", "%m"),
+    ("dd", "%d"),
+    ("HH", "%H"),
+    ("mm", "%M"),
+    ("ss", "%S"),
+]
+
+
+def _convert_spark_datetime_pattern_to_strftime(fmt: str) -> str:
+    """Translate a Spark datetime pattern to ``strftime`` for :func:`date_format` output."""
+    out = fmt
+    for spark_pat, strf in _SPARK_DATETIME_STRFTIME_MAP:
+        out = out.replace(spark_pat, strf)
+    return out
 
 
 def _pad_microseconds_expr(expr: pl.Expr) -> pl.Expr:
@@ -491,3 +511,74 @@ class _RankWrapper(Column):
 
     def over(self, window_spec: WindowSpec) -> Column:
         return self._fn(window_spec)
+
+
+def _map_entries_list_to_json_obj(entries: Any) -> str | None:
+    if entries is None:
+        return None
+    if not isinstance(entries, list):
+        return None
+    out: dict[str, Any] = {}
+    for e in entries:
+        if not isinstance(e, dict):
+            continue
+        k = e.get("key")
+        if k is None:
+            continue
+        out[str(k)] = e.get("value")
+    return json.dumps(out, separators=(",", ":"))
+
+
+def _is_spark_map_entry_list_dtype(list_dtype: pl.List) -> bool:
+    inner = list_dtype.inner
+    if not isinstance(inner, pl.Struct):
+        return False
+    names = {f.name for f in inner.fields}
+    return names == {"key", "value"}
+
+
+def _to_json_batch(s: pl.Series) -> pl.Series:
+    name = s.name
+    if s.len() == 0:
+        return pl.Series(name, [], dtype=pl.String)
+    dt = s.dtype
+    if isinstance(dt, pl.Struct):
+        return s.struct.json_encode()
+    if isinstance(dt, pl.List):
+        if _is_spark_map_entry_list_dtype(dt):
+            rows = s.to_list()
+            encoded = [_map_entries_list_to_json_obj(x) for x in rows]
+            return pl.Series(name, encoded, dtype=pl.String)
+        rows = s.to_list()
+
+        def _dump(v: Any) -> str | None:
+            if v is None:
+                return None
+            return json.dumps(v, separators=(",", ":"), default=str)
+
+        return pl.Series(name, [_dump(x) for x in rows], dtype=pl.String)
+    raise TypeError(
+        "to_json expects a struct column, an array column, or a sparkleframe map column "
+        f"(list<struct<key,value>>); got {dt}"
+    )
+
+
+def _rand_batch(s: pl.Series, seed: Optional[int]) -> pl.Series:
+    n = s.len()
+    if n == 0:
+        return pl.Series(s.name, [], dtype=pl.Float64)
+    rng = random.Random(seed) if seed is not None else random.Random()
+    return pl.Series(s.name, [rng.random() for _ in range(n)], dtype=pl.Float64)
+
+
+def _size_sparklike_value(v: Any) -> int | None:
+    """Row-wise length for Spark-like ``size`` when Polars dtype is not ``List`` (e.g. ``Object``)."""
+    if v is None:
+        return None
+    if isinstance(v, pl.Series):
+        return v.len()
+    if isinstance(v, list):
+        return len(v)
+    if isinstance(v, dict):
+        return len(v)
+    return None

--- a/sparkleframe/polarsdf/functions_helpers.py
+++ b/sparkleframe/polarsdf/functions_helpers.py
@@ -388,7 +388,7 @@ def _map_key_lookup_expr(col_expr: pl.Expr, key_expr: pl.Expr) -> pl.Expr:
     if uses_named_column:
         return pl.struct([col_expr.alias("_map"), key_expr.alias("_key")]).map_elements(
             lambda row: _lookup_map_value_by_key(row["_map"], row["_key"]),
-            return_dtype=pl.Object,
+            return_dtype=None,
         )
 
     return (
@@ -418,19 +418,32 @@ def element_at_column(
     col_expr = _to_expr(col_name) if isinstance(col_name, Column) else pl.col(col_name)
 
     if isinstance(extraction, Column):
-        key_expr = extraction.to_native()
-        return Column(_map_key_lookup_expr(col_expr, key_expr))
+        extraction = extraction.to_native()
+
+    if isinstance(extraction, pl.Expr):
+        try:
+            lit_value = pl.DataFrame({"_x": [0]}).select(extraction.alias("_v"))["_v"][0]
+            if isinstance(lit_value, int):
+                extraction = lit_value
+        except Exception:
+            pass
 
     if isinstance(extraction, pl.Expr):
         return Column(_map_key_lookup_expr(col_expr, extraction))
 
     if isinstance(extraction, int):
-        idx = extraction
+        if extraction == 0:
+            if strict:
+                raise ValueError("element_at: index 0 is invalid (Spark uses 1-based indexing)")
+            return Column(pl.lit(None))
+        polars_idx = extraction - 1 if extraction > 0 else extraction
+        if strict:
 
-        def _one(arr: Any) -> Any:
-            return _array_element_at_value(arr, idx, strict=strict)
+            def _strict_get(arr: Any) -> Any:
+                return _array_element_at_value(arr, extraction, strict=True)
 
-        return Column(col_expr.map_elements(_one, return_dtype=pl.Object))
+            return Column(col_expr.map_elements(_strict_get, return_dtype=pl.String))
+        return Column(col_expr.list.get(polars_idx, null_on_oob=True))
 
     if isinstance(extraction, str):
         if strict:
@@ -582,3 +595,128 @@ def _size_sparklike_value(v: Any) -> int | None:
     if isinstance(v, dict):
         return len(v)
     return None
+
+
+def _transform_produces_struct(expr: pl.Expr) -> bool:
+    """Return True when the expression contains ``pl.struct`` (Polars ``AsStruct``).
+
+    Polars cannot evaluate ``pl.struct`` inside ``list.eval``, so ``transform``
+    must fall back to a Python-side row-wise approach.  Serialization may fail
+    when the expression tree contains Python UDFs, so we fall back to the
+    string representation.
+    """
+    try:
+        return b"AsStruct" in expr.meta.serialize()
+    except Exception:
+        try:
+            return "as_struct(" in str(expr)
+        except Exception:
+            return False
+
+
+def _transform_struct_batch(s: pl.Series, func: Any) -> pl.Series:
+    """Apply *func* element-wise to each list cell, returning a list-of-dicts series.
+
+    Used as the ``map_batches`` callback when :func:`transform`'s lambda produces a
+    struct — Polars' ``list.eval`` cannot handle ``pl.struct`` natively.
+
+    Each element is placed in a 1-row DataFrame and referenced via ``pl.col("_x")``
+    so that nested types (lists, structs) are preserved correctly — ``pl.lit()``
+    flattens lists into separate rows.
+
+    Polars also rejects ``as_struct`` wrapping Python UDFs (``nested objects are not
+    allowed``), so struct fields are evaluated individually and combined into a dict.
+
+    The returned series has a concrete ``List(Struct(...))`` dtype inferred from the
+    first non-null result so that ``map_batches`` produces a properly-typed column.
+    """
+    from sparkleframe.polarsdf.column import Column as _Col
+
+    results: list[list[dict] | None] = []
+    for cell in s:
+        if cell is None:
+            results.append(None)
+            continue
+        row_results: list[dict] = []
+        for elem in cell:
+            elem_col = _Col(pl.col("_x"))
+            out = func(elem_col)
+            tiny_df = pl.DataFrame({"_x": [elem]})
+            if isinstance(out, _Col) and out._struct_parts is not None:
+                row_dict: dict[str, Any] = {}
+                for part_expr in out._struct_parts:
+                    name = part_expr.meta.output_name()
+                    val = tiny_df.select(part_expr.alias("_r"))["_r"][0]
+                    row_dict[name] = val
+                row_results.append(row_dict)
+            else:
+                out_expr = out.to_native() if isinstance(out, _Col) else _to_expr(out)
+                val = tiny_df.select(out_expr.alias("_r"))["_r"][0]
+                row_results.append(val)
+        results.append(row_results)
+
+    struct_dtype = _infer_list_struct_dtype(results)
+    if struct_dtype is not None:
+        return pl.Series(results, dtype=struct_dtype)
+    return pl.Series(results)
+
+
+def _infer_list_struct_dtype(results: list) -> Optional[pl.DataType]:
+    """Infer ``List(Struct(...))`` dtype from the first non-null dict in *results*."""
+    for cell in results:
+        if cell is None:
+            continue
+        for row in cell:
+            if isinstance(row, dict) and row:
+                fields: list[pl.Field] = []
+                for k, v in row.items():
+                    if isinstance(v, bool):
+                        fields.append(pl.Field(k, pl.Boolean))
+                    elif isinstance(v, int):
+                        fields.append(pl.Field(k, pl.Int64))
+                    elif isinstance(v, float):
+                        fields.append(pl.Field(k, pl.Float64))
+                    else:
+                        fields.append(pl.Field(k, pl.Utf8))
+                return pl.List(pl.Struct(fields))
+    return None
+
+
+def _infer_struct_return_dtype_from_expr(expr: pl.Expr) -> pl.DataType:
+    """Extract struct field names from an expression's string representation.
+
+    When ``_struct_parts`` is unavailable (e.g. struct wrapped in ``when/otherwise``),
+    this parses ``.alias("name")`` patterns from the expression tree to build a
+    ``List(Struct(...))`` dtype.  Falls back to a single-field struct rather than
+    ``pl.Object``, which causes Polars panics in ``map_batches``.
+    """
+    try:
+        expr_str = str(expr)
+        aliases = re.findall(r'\.alias\(["\']([^"\']+)["\']\)', expr_str)
+        if aliases:
+            seen: list[str] = []
+            for a in aliases:
+                if a not in seen:
+                    seen.append(a)
+            fields = [pl.Field(name, pl.Utf8) for name in seen]
+            return pl.List(pl.Struct(fields))
+    except Exception:
+        pass
+    return pl.List(pl.Struct([pl.Field("value", pl.Utf8)]))
+
+
+def _struct_return_dtype_from_parts(struct_parts: list[pl.Expr]) -> pl.DataType:
+    """Build a ``List(Struct(...))`` dtype from struct part expressions.
+
+    Field types default to ``Utf8`` since they cannot be determined without data.
+    The actual batch function infers concrete types from the data; Polars casts
+    the result if the declared ``return_dtype`` doesn't match exactly.
+    """
+    fields: list[pl.Field] = []
+    for part_expr in struct_parts:
+        try:
+            name = part_expr.meta.output_name()
+        except Exception:
+            name = f"col{len(fields) + 1}"
+        fields.append(pl.Field(name, pl.Utf8))
+    return pl.List(pl.Struct(fields))

--- a/sparkleframe/polarsdf/functions_test.py
+++ b/sparkleframe/polarsdf/functions_test.py
@@ -16,6 +16,7 @@ from pyspark.sql.functions import asc_nulls_last as spark_asc_nulls_last
 from pyspark.sql.functions import coalesce as spark_coalesce
 from pyspark.sql.functions import col as spark_col
 from pyspark.sql.functions import concat as spark_concat
+from pyspark.sql.functions import count as spark_count
 from pyspark.sql.functions import create_map as spark_create_map
 from pyspark.sql.functions import current_date as spark_current_date
 from pyspark.sql.functions import current_timestamp as spark_current_timestamp
@@ -91,6 +92,7 @@ from sparkleframe.polarsdf.functions import (
     coalesce,
     col,
     concat,
+    count,
     create_map,
     current_date,
     current_timestamp,
@@ -1724,4 +1726,30 @@ class TestSortArray:
         spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
         result_df = polars_df.select(sort_array("arr", asc=False).alias("s"))
         expected_df = spark_df.select(spark_sort_array("arr", asc=False).alias("s"))
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)
+
+
+class TestCount:
+    def test_count_star_against_spark(self, spark) -> None:
+        data = {"g": ["a", "a", "b", "b", "b"], "v": [1, None, 3, 4, None]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        result_df = polars_df.groupBy("g").agg(count("*").alias("cnt")).orderBy("g")
+        expected_df = spark_df.groupBy("g").agg(spark_count("*").alias("cnt")).orderBy("g")
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)
+
+    def test_count_column_against_spark(self, spark) -> None:
+        data = {"g": ["a", "a", "b", "b", "b"], "v": [1, None, 3, 4, None]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        result_df = polars_df.groupBy("g").agg(count("v").alias("cnt")).orderBy("g")
+        expected_df = spark_df.groupBy("g").agg(spark_count("v").alias("cnt")).orderBy("g")
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)
+
+    def test_count_star_no_groupby_against_spark(self, spark) -> None:
+        data = {"v": [1, None, 3]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        result_df = polars_df.select(count("*").alias("cnt"))
+        expected_df = spark_df.select(spark_count("*").alias("cnt"))
         assert_sparkle_spark_frame_are_equal(result_df, expected_df)

--- a/sparkleframe/polarsdf/functions_test.py
+++ b/sparkleframe/polarsdf/functions_test.py
@@ -1468,13 +1468,19 @@ class TestMapFunctions:
         assert_sparkle_spark_frame_are_equal(result_df, expected_df)
 
     def test_map_from_entries_against_spark(self, spark) -> None:
+        """map_from_entries produces a map that getItem can look up by key,
+        matching Spark's MapType semantics."""
         from pyspark.sql import Row
 
         entries = [Row(key="a", value=1), Row(key="b", value=2)]
         spark_df = spark.createDataFrame([Row(entries=entries)])
         polars_df = DataFrame(pl.DataFrame({"entries": [[{"key": "a", "value": 1}, {"key": "b", "value": 2}]]}))
-        expected_df = spark_df.select(spark_map_from_entries("entries").alias("m"))
-        result_df = polars_df.select(map_from_entries("entries").alias("m"))
+        expected_df = spark_df.select(spark_map_from_entries("entries").alias("m")).select(
+            spark_col("m").getItem("a").alias("val_a")
+        )
+        result_df = polars_df.select(map_from_entries("entries").alias("m")).select(
+            col("m").getItem("a").alias("val_a")
+        )
         assert_sparkle_spark_frame_are_equal(result_df, expected_df)
 
 
@@ -1535,6 +1541,40 @@ class TestBroadcast:
     def test_broadcast_returns_same_dataframe(self) -> None:
         d = DataFrame(pl.DataFrame({"x": [1]}))
         assert broadcast(d) is d
+
+
+class TestWhenLitNonePreservesType:
+    def test_when_lit_none_preserves_double_type(self, spark) -> None:
+        """lit(None) inside when/then must not force the result to String.
+        PySpark infers the type from the non-null branch; sparkleframe must match."""
+        data = {"price": [10.0, -1.0, 5.0]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        result_df = polars_df.withColumn("price", when(col("price") <= 0, lit(None)).otherwise(col("price")))
+        expected_df = spark_df.withColumn(
+            "price", spark_when(spark_col("price") <= 0, spark_lit(None)).otherwise(spark_col("price"))
+        )
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)
+
+    def test_when_lit_none_preserves_integer_type(self, spark) -> None:
+        data = {"v": [1, -2, 3]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        result_df = polars_df.withColumn("v", when(col("v") < 0, lit(None)).otherwise(col("v")))
+        expected_df = spark_df.withColumn(
+            "v", spark_when(spark_col("v") < 0, spark_lit(None)).otherwise(spark_col("v"))
+        )
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)
+
+    def test_when_lit_none_preserves_string_type(self, spark) -> None:
+        data = {"s": ["hello", "", "world"]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        result_df = polars_df.withColumn("s", when(col("s") == "", lit(None)).otherwise(col("s")))
+        expected_df = spark_df.withColumn(
+            "s", spark_when(spark_col("s") == "", spark_lit(None)).otherwise(spark_col("s"))
+        )
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)
 
 
 class TestToJsonParity:
@@ -1753,3 +1793,350 @@ class TestCount:
         result_df = polars_df.select(count("*").alias("cnt"))
         expected_df = spark_df.select(spark_count("*").alias("cnt"))
         assert_sparkle_spark_frame_are_equal(result_df, expected_df)
+
+
+class TestAbs:
+    def test_abs_against_spark(self, spark) -> None:
+        data = {"v": [-3.5, 0.0, 2.1, -7.0, None]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        result_df = polars_df.select(abs(col("v")).alias("a"))
+        expected_df = spark_df.select(spark_abs(spark_col("v")).alias("a"))
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)
+
+    def test_abs_integer_against_spark(self, spark) -> None:
+        data = {"v": [-10, 0, 5, -1, None]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        result_df = polars_df.select(abs("v").alias("a"))
+        expected_df = spark_df.select(spark_abs("v").alias("a"))
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)
+
+    def test_abs_expression_against_spark(self, spark) -> None:
+        data = {"a": [1.0, 5.0, 3.0], "b": [4.0, 2.0, 3.0]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        result_df = polars_df.withColumn("diff", abs(col("a") - col("b")))
+        expected_df = spark_df.withColumn("diff", spark_abs(spark_col("a") - spark_col("b")))
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)
+
+    def test_abs_of_subtraction_withcolumn_against_spark(self, spark) -> None:
+        """Regression: arithmetic with unresolved dtypes chained with abs() via withColumn
+        must not produce an untyped UDF (Polars rejects map_batches without return_dtype)."""
+        data = {"x": [1.0, 5.0, 3.0], "y": [4.0, 2.0, 3.0]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        result_df = polars_df.withColumn("d", abs(col("x") - col("y")))
+        expected_df = spark_df.withColumn("d", spark_abs(spark_col("x") - spark_col("y")))
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)
+
+
+class TestStructFieldNaming:
+    def test_struct_child_field_name_with_alias_on_element_expr(self) -> None:
+        """Regression: _struct_child_field_name must not crash on expressions derived
+        from pl.element() (no root column name). The alias set on the Column wrapper
+        should be used as the field name."""
+        from sparkleframe.polarsdf.functions import _struct_child_field_name
+
+        elem_col = col("x").alias("key")
+        expr = elem_col.to_native()
+        name = _struct_child_field_name(elem_col, expr, 0)
+        assert name == "key"
+
+    def test_struct_child_field_name_fallback_without_alias(self) -> None:
+        """When output_name() fails and no alias is set, fall back to col{N+1}."""
+        from sparkleframe.polarsdf.functions import _struct_child_field_name
+
+        class _FakeExprMeta:
+            def output_name(self):
+                raise Exception("no root column")
+
+            def undo_aliases(self):
+                raise Exception("no root column")
+
+            def serialize(self):
+                raise Exception("no root column")
+
+        class _FakeExpr:
+            meta = _FakeExprMeta()
+
+        plain_col = col("x")
+        plain_col._output_alias = None
+        name = _struct_child_field_name(plain_col, _FakeExpr(), 2)
+        assert name == "col3"
+
+    def test_struct_from_aliased_columns_against_spark(self, spark) -> None:
+        from pyspark.sql.functions import struct as spark_struct
+
+        data = {"a": [1, 2], "b": ["x", "y"]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        result_df = polars_df.select(struct(col("a").alias("k"), col("b").alias("v")).alias("s"))
+        expected_df = spark_df.select(spark_struct(spark_col("a").alias("k"), spark_col("b").alias("v")).alias("s"))
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)
+
+
+class TestTransformStruct:
+    def test_transform_struct_and_explode_against_spark(self, spark) -> None:
+        """Regression: transform with a struct-producing lambda must not produce
+        FixedSizeBinary. The result must be explodable and match PySpark."""
+        data = {"items": [["a=1", "b=2"], ["c=3"]]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+
+        sf = polars_df.withColumn("items", transform(col("items"), lambda x: split(x, "=", 2)))
+        sp = spark_df.withColumn("items", spark_transform(spark_col("items"), lambda x: spark_split(x, "=", 2)))
+
+        sf = sf.withColumn(
+            "items",
+            transform(
+                col("items"),
+                lambda x: struct(element_at(x, 1).alias("key"), element_at(x, 2).alias("value")),
+            ),
+        )
+        sp = sp.withColumn(
+            "items",
+            spark_transform(
+                spark_col("items"),
+                lambda x: spark_struct(spark_element_at(x, 1).alias("key"), spark_element_at(x, 2).alias("value")),
+            ),
+        )
+
+        sf_exploded = sf.withColumn("item", explode("items")).select("item")
+        sp_exploded = sp.withColumn("item", spark_explode_outer(spark_col("items"))).select("item")
+        assert_sparkle_spark_frame_are_equal(sf_exploded, sp_exploded)
+
+    def test_transform_struct_inside_when_otherwise_against_spark(self, spark) -> None:
+        """Regression: transform+struct wrapped in when/otherwise must preserve
+        List(Struct) type — lit(None) must not collapse the column to Null."""
+        data = {"items": [["a=1", "b=2"], None, ["c=3"]]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+
+        def struct_lambda_sf(x):
+            return struct(element_at(x, 1).alias("key"), element_at(x, 2).alias("value"))
+
+        def struct_lambda_sp(x):
+            return spark_struct(spark_element_at(x, 1).alias("key"), spark_element_at(x, 2).alias("value"))
+
+        sf = polars_df.withColumn("items", transform(col("items"), lambda x: split(x, "=", 2)))
+        sp = spark_df.withColumn("items", spark_transform(spark_col("items"), lambda x: spark_split(x, "=", 2)))
+
+        sf = sf.withColumn(
+            "items",
+            when(col("items").isNotNull(), transform(col("items"), struct_lambda_sf)).otherwise(lit(None)),
+        )
+        sp = sp.withColumn(
+            "items",
+            spark_when(
+                spark_col("items").isNotNull(), spark_transform(spark_col("items"), struct_lambda_sp)
+            ).otherwise(spark_lit(None)),
+        )
+
+        sf = sf.withColumn("items", filter(col("items"), lambda x: x.isNotNull()))
+        sp = sp.withColumn("items", spark_filter(spark_col("items"), lambda x: x.isNotNull()))
+        assert_sparkle_spark_frame_are_equal(sf, sp)
+
+
+class TestFilterStructField:
+    def test_filter_by_struct_field_equality_against_spark(self, spark) -> None:
+        """Regression: filter lambda using getItem + == on a List(Struct) column must
+        produce native expressions (not Object-typed UDFs) so list.eval works."""
+        data = {
+            "pairs": [
+                [{"key": "utm_source", "value": "google"}, {"key": "utm_medium", "value": "cpc"}],
+                [{"key": "other", "value": "x"}],
+            ]
+        }
+        from pyspark.sql.types import ArrayType as SparkArrayType
+        from pyspark.sql.types import StringType as SparkStringType
+        from pyspark.sql.types import StructField as SparkStructField
+        from pyspark.sql.types import StructType as SparkStructType
+
+        spark_schema = SparkStructType(
+            [
+                SparkStructField(
+                    "pairs",
+                    SparkArrayType(
+                        SparkStructType(
+                            [SparkStructField("key", SparkStringType()), SparkStructField("value", SparkStringType())]
+                        )
+                    ),
+                )
+            ]
+        )
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), schema=spark_schema)
+
+        sf = polars_df.withColumn("pairs", filter(col("pairs"), lambda x: x.getItem("key") == lit("utm_source")))
+        sp = spark_df.withColumn(
+            "pairs",
+            spark_filter(spark_col("pairs"), lambda x: x.getItem("key") == spark_lit("utm_source")),
+        )
+        assert_sparkle_spark_frame_are_equal(sf, sp)
+
+    def test_getitem_on_struct_inside_transform_against_spark(self, spark) -> None:
+        """getItem on a struct element inside transform must return typed values,
+        not Object-typed UDF results."""
+        data = {
+            "pairs": [
+                [{"key": "a", "value": "1"}, {"key": "b", "value": "2"}],
+            ]
+        }
+        from pyspark.sql.types import ArrayType as SparkArrayType
+        from pyspark.sql.types import StringType as SparkStringType
+        from pyspark.sql.types import StructField as SparkStructField
+        from pyspark.sql.types import StructType as SparkStructType
+
+        spark_schema = SparkStructType(
+            [
+                SparkStructField(
+                    "pairs",
+                    SparkArrayType(
+                        SparkStructType(
+                            [SparkStructField("key", SparkStringType()), SparkStructField("value", SparkStringType())]
+                        )
+                    ),
+                )
+            ]
+        )
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), schema=spark_schema)
+
+        sf = polars_df.withColumn("keys", transform(col("pairs"), lambda x: x.getItem("key")))
+        sp = spark_df.withColumn("keys", spark_transform(spark_col("pairs"), lambda x: x.getItem("key")))
+        assert_sparkle_spark_frame_are_equal(sf, sp)
+
+
+class TestMapFromEntries:
+    """Parity tests for map_from_entries and related map operations."""
+
+    def test_map_from_entries_against_spark(self, spark) -> None:
+        """map_from_entries on List(Struct(key, value)) should produce a map
+        that getItem can look up by key."""
+        data = {
+            "entries": [
+                [{"key": "utm_source", "value": "google"}, {"key": "utm_medium", "value": "cpc"}],
+                [{"key": "plan", "value": "premium"}],
+            ]
+        }
+        spark_schema = SparkStructType(
+            [
+                SparkStructField(
+                    "entries",
+                    SparkArrayType(
+                        SparkStructType(
+                            [SparkStructField("key", SparkStringType()), SparkStructField("value", SparkStringType())]
+                        )
+                    ),
+                )
+            ]
+        )
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), schema=spark_schema)
+
+        sf = polars_df.withColumn("m", map_from_entries(col("entries"))).withColumn(
+            "src", col("m").getItem("utm_source")
+        )
+        sp = spark_df.withColumn("m", spark_map_from_entries(spark_col("entries"))).withColumn(
+            "src", spark_col("m").getItem("utm_source")
+        )
+        assert_sparkle_spark_frame_are_equal(
+            sf.select("src"),
+            sp.select("src"),
+        )
+
+    def test_create_map_getitem_against_spark(self, spark) -> None:
+        """create_map + getItem should look up a value by key."""
+        polars_df = DataFrame(pl.DataFrame({"x": ["hello"], "y": ["world"]}))
+        spark_df = spark.createDataFrame(pd.DataFrame({"x": ["hello"], "y": ["world"]}))
+
+        sf = polars_df.withColumn("m", create_map(lit("x_val"), col("x"), lit("y_val"), col("y"))).withColumn(
+            "got", col("m").getItem("x_val")
+        )
+        sp = spark_df.withColumn(
+            "m", spark_create_map(spark_lit("x_val"), spark_col("x"), spark_lit("y_val"), spark_col("y"))
+        ).withColumn("got", spark_col("m").getItem("x_val"))
+        assert_sparkle_spark_frame_are_equal(
+            sf.select("got"),
+            sp.select("got"),
+        )
+
+
+class TestElementAtWithLitIndex:
+    """Parity tests for element_at / try_element_at with F.lit(int) index."""
+
+    def test_try_element_at_with_lit_int_against_spark(self, spark) -> None:
+        """try_element_at(array, F.lit(1)) should extract the first element."""
+        spark_schema = SparkStructType([SparkStructField("arr", SparkArrayType(SparkStringType()))])
+        polars_df = DataFrame(pl.DataFrame({"arr": [["a", "b", "c"]]}))
+        spark_df = spark.createDataFrame([(["a", "b", "c"],)], schema=spark_schema)
+
+        sf = polars_df.withColumn("first", try_element_at(col("arr"), lit(1)))
+        sp = spark_df.withColumn("first", spark_try_element_at(spark_col("arr"), spark_lit(1)))
+        assert_sparkle_spark_frame_are_equal(sf.select("first"), sp.select("first"))
+
+    def test_element_at_with_lit_int_against_spark(self, spark) -> None:
+        """element_at(array, F.lit(2)) should extract the second element."""
+        spark_schema = SparkStructType([SparkStructField("arr", SparkArrayType(SparkStringType()))])
+        polars_df = DataFrame(pl.DataFrame({"arr": [["x", "y", "z"]]}))
+        spark_df = spark.createDataFrame([(["x", "y", "z"],)], schema=spark_schema)
+
+        sf = polars_df.withColumn("second", element_at(col("arr"), lit(2)))
+        sp = spark_df.withColumn("second", spark_element_at(spark_col("arr"), spark_lit(2)))
+        assert_sparkle_spark_frame_are_equal(sf.select("second"), sp.select("second"))
+
+
+class TestGetItemOnListInFilter:
+    """Parity tests for getItem on a list column used inside filter."""
+
+    def test_getitem_int_in_filter_against_spark(self, spark) -> None:
+        """filter(col('arr').getItem(0).isNotNull()) should keep non-null first elements."""
+        spark_schema = SparkStructType([SparkStructField("arr", SparkArrayType(SparkStringType()))])
+        polars_df = DataFrame(pl.DataFrame({"arr": [["a", "b"], None, ["c"]]}))
+        spark_df = spark.createDataFrame(
+            [(["a", "b"],), (None,), (["c"],)],
+            schema=spark_schema,
+        )
+
+        sf = polars_df.filter(col("arr").getItem(0).isNotNull())
+        sp = spark_df.filter(spark_col("arr").getItem(0).isNotNull())
+        assert_sparkle_spark_frame_are_equal(sf, sp)
+
+    def test_getitem_string_key_on_map_in_filter_against_spark(self, spark) -> None:
+        """getItem on a map-as-struct column inside filter must resolve values."""
+        data = {
+            "entries": [
+                [{"key": "a", "value": "1"}],
+                [{"key": "b", "value": "2"}],
+            ]
+        }
+        spark_schema = SparkStructType(
+            [
+                SparkStructField(
+                    "entries",
+                    SparkArrayType(
+                        SparkStructType(
+                            [SparkStructField("key", SparkStringType()), SparkStructField("value", SparkStringType())]
+                        )
+                    ),
+                )
+            ]
+        )
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), schema=spark_schema)
+
+        sf = (
+            polars_df.withColumn("m", map_from_entries(col("entries")))
+            .withColumn("got", col("m").getItem("a"))
+            .filter(col("got").isNotNull())
+        )
+        sp = (
+            spark_df.withColumn("m", spark_map_from_entries(spark_col("entries")))
+            .withColumn("got", spark_col("m").getItem("a"))
+            .filter(spark_col("got").isNotNull())
+        )
+        assert_sparkle_spark_frame_are_equal(
+            sf.select("got"),
+            sp.select("got"),
+        )

--- a/sparkleframe/polarsdf/functions_test.py
+++ b/sparkleframe/polarsdf/functions_test.py
@@ -16,8 +16,10 @@ from pyspark.sql.functions import asc_nulls_last as spark_asc_nulls_last
 from pyspark.sql.functions import coalesce as spark_coalesce
 from pyspark.sql.functions import col as spark_col
 from pyspark.sql.functions import concat as spark_concat
+from pyspark.sql.functions import create_map as spark_create_map
 from pyspark.sql.functions import current_date as spark_current_date
 from pyspark.sql.functions import current_timestamp as spark_current_timestamp
+from pyspark.sql.functions import date_format as spark_date_format
 from pyspark.sql.functions import date_sub as spark_date_sub
 from pyspark.sql.functions import datediff as spark_datediff
 from pyspark.sql.functions import dense_rank as spark_dense_rank
@@ -28,9 +30,13 @@ from pyspark.sql.functions import element_at as spark_element_at
 from pyspark.sql.functions import explode_outer as spark_explode_outer
 from pyspark.sql.functions import filter as spark_filter
 from pyspark.sql.functions import first as spark_first
+from pyspark.sql.functions import floor as spark_floor
 from pyspark.sql.functions import from_json as spark_from_json
 from pyspark.sql.functions import get_json_object as spark_get_json_object
+from pyspark.sql.functions import greatest as spark_greatest
 from pyspark.sql.functions import initcap as spark_initcap
+from pyspark.sql.functions import isnan as spark_isnan
+from pyspark.sql.functions import least as spark_least
 from pyspark.sql.functions import length as spark_length
 from pyspark.sql.functions import lit as spark_lit
 from pyspark.sql.functions import lower as spark_lower
@@ -40,18 +46,24 @@ from pyspark.sql.functions import md5 as spark_md5
 from pyspark.sql.functions import monotonically_increasing_id as spark_monotonically_increasing_id
 from pyspark.sql.functions import months_between as spark_months_between
 from pyspark.sql.functions import now as spark_now
+from pyspark.sql.functions import nullif as spark_nullif
+from pyspark.sql.functions import pow as spark_pow
+from pyspark.sql.functions import rand as spark_rand
 from pyspark.sql.functions import rank as spark_rank
 from pyspark.sql.functions import regexp_replace as spark_regexp_replace
 from pyspark.sql.functions import round as spark_round
 from pyspark.sql.functions import row_number as spark_row_number
 from pyspark.sql.functions import size as spark_size
+from pyspark.sql.functions import sort_array as spark_sort_array
 from pyspark.sql.functions import split as spark_split
 from pyspark.sql.functions import struct as spark_struct
 from pyspark.sql.functions import substring as spark_substring
 from pyspark.sql.functions import to_date as spark_to_date
+from pyspark.sql.functions import to_json as spark_to_json
 from pyspark.sql.functions import to_timestamp as spark_to_timestamp
 from pyspark.sql.functions import transform as spark_transform
 from pyspark.sql.functions import trim as spark_trim
+from pyspark.sql.functions import try_divide as spark_try_divide
 from pyspark.sql.functions import try_element_at as spark_try_element_at
 from pyspark.sql.functions import try_to_date as spark_try_to_date
 from pyspark.sql.functions import try_to_timestamp as spark_try_to_timestamp
@@ -79,8 +91,10 @@ from sparkleframe.polarsdf.functions import (
     coalesce,
     col,
     concat,
+    create_map,
     current_date,
     current_timestamp,
+    date_format,
     date_sub,
     datediff,
     dense_rank,
@@ -91,9 +105,13 @@ from sparkleframe.polarsdf.functions import (
     explode,
     filter,
     first,
+    floor,
     from_json,
     get_json_object,
+    greatest,
     initcap,
+    isnan,
+    least,
     length,
     lit,
     lower,
@@ -103,12 +121,15 @@ from sparkleframe.polarsdf.functions import (
     monotonically_increasing_id,
     months_between,
     now,
+    nullif,
+    pow,
     rand,
     rank,
     regexp_replace,
     round,
     row_number,
     size,
+    sort_array,
     split,
     struct,
     substring,
@@ -117,6 +138,7 @@ from sparkleframe.polarsdf.functions import (
     to_timestamp,
     transform,
     trim,
+    try_divide,
     try_element_at,
     try_to_date,
     try_to_timestamp,
@@ -1511,3 +1533,196 @@ class TestBroadcast:
     def test_broadcast_returns_same_dataframe(self) -> None:
         d = DataFrame(pl.DataFrame({"x": [1]}))
         assert broadcast(d) is d
+
+
+class TestToJsonParity:
+    def test_to_json_struct_against_spark(self, spark) -> None:
+        data = {"a": [1, 2], "b": ["x", "y"]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        result_df = polars_df.select(to_json(struct("a", "b")).alias("j"))
+        expected_df = spark_df.select(spark_to_json(spark_struct("a", "b")).alias("j"))
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)
+
+    def test_to_json_array_against_spark(self, spark) -> None:
+        from pyspark.sql.functions import array as spark_array
+
+        data = {"a": [1, 2], "b": [3, 4]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        result_df = polars_df.select(to_json(array("a", "b")).alias("j"))
+        expected_df = spark_df.select(spark_to_json(spark_array("a", "b")).alias("j"))
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)
+
+
+class TestLeastGreatest:
+    def test_least_against_spark(self, spark) -> None:
+        data = {"a": [10, 1, None], "b": [5, None, 3], "c": [8, 2, 7]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        result_df = polars_df.select(least("a", "b", "c").alias("min"))
+        expected_df = spark_df.select(spark_least("a", "b", "c").alias("min"))
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)
+
+    def test_greatest_against_spark(self, spark) -> None:
+        data = {"a": [10, 1, None], "b": [5, None, 3], "c": [8, 2, 7]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        result_df = polars_df.select(greatest("a", "b", "c").alias("max"))
+        expected_df = spark_df.select(spark_greatest("a", "b", "c").alias("max"))
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)
+
+    def test_least_all_nulls_returns_null(self, spark) -> None:
+        data = {"a": [None, None], "b": [None, None]}
+        polars_df = DataFrame(
+            pl.DataFrame({"a": pl.Series([None, None], dtype=pl.Int64), "b": pl.Series([None, None], dtype=pl.Int64)})
+        )
+        from pyspark.sql.types import LongType as SparkLongType
+
+        schema = SparkStructType(
+            [SparkStructField("a", SparkLongType(), True), SparkStructField("b", SparkLongType(), True)]
+        )
+        spark_df = spark.createDataFrame([(None, None), (None, None)], schema)
+        result_df = polars_df.select(least("a", "b").alias("min"))
+        expected_df = spark_df.select(spark_least("a", "b").alias("min"))
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)
+
+
+class TestCreateMap:
+    def test_create_map_against_spark(self, spark) -> None:
+        data = {"k": ["a", "b"], "v": [1, 2]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        result_df = polars_df.select(to_json(create_map("k", "v")).alias("j"))
+        expected_df = spark_df.select(spark_to_json(spark_create_map("k", "v")).alias("j"))
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)
+
+
+class TestArrayParity:
+    def test_array_against_spark(self, spark) -> None:
+        from pyspark.sql.functions import array as spark_array
+
+        data = {"a": [1, 2, 3], "b": [4, 5, 6]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        result_df = polars_df.select(array("a", "b").alias("arr"))
+        expected_df = spark_df.select(spark_array("a", "b").alias("arr"))
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)
+
+
+class TestDateFormat:
+    def test_date_format_against_spark(self, spark) -> None:
+        data = {"ts": ["2023-01-15 10:30:45", "2024-12-25 00:00:00"]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+
+        sf_ts = polars_df.select(date_format(to_timestamp("ts"), "yyyy-MM-dd").alias("d"))
+        sp_ts = spark_df.select(spark_date_format(spark_to_timestamp("ts"), "yyyy-MM-dd").alias("d"))
+        assert_sparkle_spark_frame_are_equal(sf_ts, sp_ts)
+
+    def test_date_format_time_parts_against_spark(self, spark) -> None:
+        data = {"ts": ["2023-06-15 14:05:09"]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+
+        sf = polars_df.select(date_format(to_timestamp("ts"), "HH:mm:ss").alias("t"))
+        sp = spark_df.select(spark_date_format(spark_to_timestamp("ts"), "HH:mm:ss").alias("t"))
+        assert_sparkle_spark_frame_are_equal(sf, sp)
+
+
+class TestFloor:
+    def test_floor_against_spark(self, spark) -> None:
+        data = {"v": [1.9, 2.1, -0.5, 0.0, None]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        result_df = polars_df.select(floor("v").alias("f"))
+        expected_df = spark_df.select(spark_floor("v").alias("f"))
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)
+
+
+class TestPow:
+    def test_pow_against_spark(self, spark) -> None:
+        data = {"base": [2.0, 3.0, 10.0], "exp": [3.0, 2.0, 0.0]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        result_df = polars_df.select(pow("base", "exp").alias("p"))
+        expected_df = spark_df.select(spark_pow("base", "exp").alias("p"))
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)
+
+    def test_pow_with_literal_exponent_against_spark(self, spark) -> None:
+        data = {"base": [2.0, 3.0, 4.0]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        result_df = polars_df.select(pow(col("base"), lit(2)).alias("p"))
+        expected_df = spark_df.select(spark_pow(spark_col("base"), spark_lit(2)).alias("p"))
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)
+
+
+class TestIsnan:
+    def test_isnan_against_spark(self, spark) -> None:
+        data = {"v": [1.0, float("nan"), None, 0.0]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        result_df = polars_df.select(isnan("v").alias("n"))
+        expected_df = spark_df.select(spark_isnan("v").alias("n"))
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)
+
+
+class TestTryDivide:
+    def test_try_divide_against_spark(self, spark) -> None:
+        data = {"a": [10.0, 9.0, None, 5.0], "b": [2.0, 0.0, 3.0, None]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        result_df = polars_df.select(try_divide("a", "b").alias("d"))
+        expected_df = spark_df.select(spark_try_divide("a", "b").alias("d"))
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)
+
+
+class TestNullif:
+    def test_nullif_against_spark(self, spark) -> None:
+        data = {"a": [1, 2, 3, None], "b": [1, 3, 3, None]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        result_df = polars_df.select(nullif("a", "b").alias("n"))
+        expected_df = spark_df.select(spark_nullif("a", "b").alias("n"))
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)
+
+    def test_nullif_with_nulls_preserves_e1(self, spark) -> None:
+        data = {"a": [5, None, 3], "b": [None, 2, None]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        result_df = polars_df.select(nullif("a", "b").alias("n"))
+        expected_df = spark_df.select(spark_nullif("a", "b").alias("n"))
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)
+
+
+class TestRandParity:
+    def test_rand_output_shape_and_type_matches_spark(self, spark) -> None:
+        data = {"x": [1, 2, 3, 4, 5]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        sf_result = polars_df.select(rand(42).alias("r"))
+        sp_result = spark_df.select(spark_rand(42).alias("r"))
+        sf_vals = sf_result.to_native_df()["r"].to_list()
+        sp_vals = [row[0] for row in sp_result.collect()]
+        assert len(sf_vals) == len(sp_vals)
+        assert all(isinstance(v, float) and 0.0 <= v < 1.0 for v in sf_vals)
+        assert all(isinstance(v, float) and 0.0 <= v < 1.0 for v in sp_vals)
+
+
+class TestSortArray:
+    def test_sort_array_asc_against_spark(self, spark) -> None:
+        data = {"arr": [[3, 1, 2], [6, 4, 5], None]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        result_df = polars_df.select(sort_array("arr").alias("s"))
+        expected_df = spark_df.select(spark_sort_array("arr").alias("s"))
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)
+
+    def test_sort_array_desc_against_spark(self, spark) -> None:
+        data = {"arr": [[3, 1, 2], [6, 4, 5]]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        spark_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys()))
+        result_df = polars_df.select(sort_array("arr", asc=False).alias("s"))
+        expected_df = spark_df.select(spark_sort_array("arr", asc=False).alias("s"))
+        assert_sparkle_spark_frame_are_equal(result_df, expected_df)

--- a/sparkleframe/polarsdf/functions_test.py
+++ b/sparkleframe/polarsdf/functions_test.py
@@ -1573,7 +1573,6 @@ class TestLeastGreatest:
         assert_sparkle_spark_frame_are_equal(result_df, expected_df)
 
     def test_least_all_nulls_returns_null(self, spark) -> None:
-        data = {"a": [None, None], "b": [None, None]}
         polars_df = DataFrame(
             pl.DataFrame({"a": pl.Series([None, None], dtype=pl.Int64), "b": pl.Series([None, None], dtype=pl.Int64)})
         )

--- a/sparkleframe/polarsdf/functions_test.py
+++ b/sparkleframe/polarsdf/functions_test.py
@@ -17,6 +17,7 @@ from pyspark.sql.functions import coalesce as spark_coalesce
 from pyspark.sql.functions import col as spark_col
 from pyspark.sql.functions import concat as spark_concat
 from pyspark.sql.functions import current_date as spark_current_date
+from pyspark.sql.functions import current_timestamp as spark_current_timestamp
 from pyspark.sql.functions import date_sub as spark_date_sub
 from pyspark.sql.functions import datediff as spark_datediff
 from pyspark.sql.functions import dense_rank as spark_dense_rank
@@ -69,6 +70,7 @@ from sparkleframe.polarsdf import Window
 from sparkleframe.polarsdf.dataframe import DataFrame
 from sparkleframe.polarsdf.functions import (
     abs,
+    array,
     array_contains,
     asc,
     asc_nulls_first,
@@ -78,6 +80,7 @@ from sparkleframe.polarsdf.functions import (
     col,
     concat,
     current_date,
+    current_timestamp,
     date_sub,
     datediff,
     dense_rank,
@@ -100,6 +103,7 @@ from sparkleframe.polarsdf.functions import (
     monotonically_increasing_id,
     months_between,
     now,
+    rand,
     rank,
     regexp_replace,
     round,
@@ -109,6 +113,7 @@ from sparkleframe.polarsdf.functions import (
     struct,
     substring,
     to_date,
+    to_json,
     to_timestamp,
     transform,
     trim,
@@ -902,6 +907,19 @@ class TestNowAndMonotonicallyIncreasingId:
         assert len(set(ms2)) == 1
         assert builtins.abs(ms1[0] - ms2[0]) < 3_000
 
+    def test_current_timestamp_all_rows_equal_and_close_to_spark(self, spark) -> None:
+        data = {"x": [1, 2, 3]}
+        polars_df = DataFrame(pl.DataFrame(data))
+        result_spark_df = create_spark_df(spark, polars_df.select(current_timestamp().alias("t")))
+        expected_df = spark.createDataFrame(spark_rows_from_dict(data), list(data.keys())).select(
+            spark_current_timestamp().alias("t")
+        )
+        ms1 = [r[0] for r in result_spark_df.select(spark_unix_millis("t").alias("m")).collect()]
+        ms2 = [r[0] for r in expected_df.select(spark_unix_millis("t").alias("m")).collect()]
+        assert len(set(ms1)) == 1
+        assert len(set(ms2)) == 1
+        assert builtins.abs(ms1[0] - ms2[0]) < 3_000
+
     def test_monotonically_increasing_id_against_spark(self, spark) -> None:
         data = {"k": ["a", "b", "c", "d"]}
         polars_df = DataFrame(pl.DataFrame(data))
@@ -946,6 +964,62 @@ class TestToDate:
         spark_df = spark.createDataFrame([(bad_value,)], ["d"])
         with pytest.raises(Exception):
             spark_df.select(spark_to_date("d", fmt).alias("result")).collect()
+
+
+class TestRand:
+    def test_rand_seeded_is_repeatable_and_in_range(self) -> None:
+        polars_df = DataFrame(pl.DataFrame({"x": [1, 2, 3, 4, 5]}))
+        a = polars_df.select(rand(42).alias("r")).to_native_df()["r"].to_list()
+        b = polars_df.select(rand(42).alias("r")).to_native_df()["r"].to_list()
+        assert a == b
+        assert all(isinstance(v, float) and 0.0 <= v < 1.0 for v in a)
+
+    def test_rand_unseeded_values_in_unit_interval(self) -> None:
+        polars_df = DataFrame(pl.DataFrame({"x": list(range(50))}))
+        vals = polars_df.select(rand().alias("r")).to_native_df()["r"].to_list()
+        assert all(isinstance(v, float) and 0.0 <= v < 1.0 for v in vals)
+
+
+class TestArray:
+    def test_array_empty_broadcasts_per_row(self) -> None:
+        polars_df = DataFrame(pl.DataFrame({"x": [1, 2]}))
+        col_vals = polars_df.withColumn("a", array()).to_native_df()["a"].to_list()
+        assert col_vals == [[], []]
+
+    def test_array_from_column_names(self) -> None:
+        polars_df = DataFrame(pl.DataFrame({"a": [1, 2], "b": [3, 4]}))
+        col_vals = polars_df.select(array("a", "b").alias("m")).to_native_df()["m"].to_list()
+        assert col_vals == [[1, 3], [2, 4]]
+
+
+class TestSizeObjectList:
+    """``size`` on Polars ``Object`` list cells (nested JSON-like structs)."""
+
+    def test_size_object_list_select(self) -> None:
+        offers = pl.Series("offers", [[1, 2], [], None, [3]], dtype=pl.Object)
+        df = DataFrame(pl.DataFrame([offers]))
+        assert df.select(size("offers").alias("sz")).to_native_df()["sz"].to_list() == [2, 0, None, 1]
+
+    def test_size_typed_list_column(self) -> None:
+        df = DataFrame(pl.DataFrame({"arr": [[1, 2], [], [3]]}))
+        assert df.select(size("arr").alias("sz")).to_native_df()["sz"].to_list() == [2, 0, 1]
+
+    def test_filter_or_on_object_list_columns_like_heloc(self) -> None:
+        """Spark ``size`` + ``filter`` on list fields that Polars stores as ``Object``."""
+        offers = pl.Series("replacements_offers", [[1, 2], None, [], [3]], dtype=pl.Object)
+        loans = pl.Series("replacements_loans", [[], [3], [], []], dtype=pl.Object)
+        df = DataFrame(pl.DataFrame([offers, loans]))
+        replaceable_offer_has_items = col("replacements_offers").isNotNull() & (size(col("replacements_offers")) > 0)
+        replaceable_loans_has_items = col("replacements_loans").isNotNull() & (size(col("replacements_loans")) > 0)
+        out = df.filter(replaceable_offer_has_items | replaceable_loans_has_items)
+        assert out.count() == 3
+
+
+class TestToJson:
+    def test_options_argument_rejected(self) -> None:
+        polars_df = DataFrame(pl.DataFrame({"a": [1]}))
+        with pytest.raises(ValueError):
+            polars_df.select(to_json(struct("a"), {"timestampFormat": "yyyy"}).alias("j"))
 
 
 class TestTryToTimestamp:


### PR DESCRIPTION
## Summary

Additional Column, DataFrame, and functions improvements with helpers refactored into dedicated modules, plus critical fixes for Object-type poisoning and runtime type validation.

### Key changes

- **Runtime arithmetic validation**: When dtypes are unknown at expression build time, `map_batches` validates actual Series dtypes at evaluation time, rejecting boolean/string/binary/complex operands to match Spark's `AnalysisException` behavior. Fixes 51 previously failing arithmetic parity tests.
- **Object-type poisoning fixes**: `getItem` and `element_at` UDF fallbacks now handle `pl.Series` inputs correctly, preventing null results when called outside schema context (e.g. inside `filter()`). Equality comparisons use a same-family type short-circuit to avoid Object-typed UDFs.
- **`transform` + `struct` parity**: `_struct_parts` metadata propagates through `WhenBuilder` so `transform` with struct-producing lambdas inside `when/otherwise` produces `List(Struct)` instead of `List(Null)` or `List(Object)`.
- **`element_at` with `F.lit(int)`**: Resolves literal integers for array indexing instead of treating them as column-based map key lookups. Restores strict raising behavior for out-of-bounds access.
- **`map_from_entries`**: Preserves input types instead of forcing cast to `String`.
- **`count("*")`**: Uses `pl.len()` (Polars equivalent of `COUNT(*)`) instead of `pl.col("*").count()`.
- **Helpers refactor**: Private helpers moved to `column_helpers.py` and `functions_helpers.py`.
- **20 new Spark parity tests**: Covering transform+struct, getItem, element_at, map_from_entries, create_map, filter, when/lit(None), abs, and struct field naming.
- **Known gaps documented** in `docs/known_gaps.md`.

## Test plan

- [x] All 1942 tests pass (0 failed, 283 xfailed) in Docker with `TIMEZONE=UTC`
- [x] NBA function Docker invoke returns `nba_action_id` with latest wheel
- [x] `isort`, `black`, and `ruff` lint all pass
- [x] 51 previously failing `TestArithmeticParityWithSpark` tests now pass
- [x] Pre-existing xfails (mixed-type arithmetic, map detection, nested ordering) unchanged