### PR TITLE
fix(CI): authenticate changelog GitHub API calls and sort releases by semver

### DIFF
--- a/scripts/calculate_version.py
+++ b/scripts/calculate_version.py
@@ -51,7 +51,7 @@ def calculate_version(to_branch: str = None, re_commit_type: str = None) -> List
         # Unable to find a previous release
         commit_list = get_commit_list(to_branch=to_branch)
     else:
-        latest_version_branch_name = max(release_branches)
+        latest_version_branch_name = release_branches[-1]
         latest_version = [int(num) for num in latest_version_branch_name[15:].split(".")]
         commit_list = get_commit_list(from_branch=latest_version_branch_name, to_branch=to_branch)
 

--- a/scripts/generate_changelog.py
+++ b/scripts/generate_changelog.py
@@ -28,7 +28,7 @@ def generate_changelog(to_branch: str=None):
         # Unable to find a previous release
         commit_list = get_commit_list(to_branch=to_branch)
     else:
-        latest_version_branch_name = max(release_branches)
+        latest_version_branch_name = release_branches[-1]
         commit_list = get_commit_list(from_branch=latest_version_branch_name, to_branch=to_branch)
 
     issues = {}

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,8 +1,18 @@
+import os
+import re
 import subprocess
 import requests
 import base64
 
-def get_github_file_content(branch, file_path, owner="flypipe", repo="sparkleframe"):
+RELEASE_BRANCH_RE = re.compile(r'^origin/release/(\d+)\.(\d+)\.(\d+)$')
+
+
+def _release_version_key(branch):
+    match = RELEASE_BRANCH_RE.match(branch)
+    return tuple(int(part) for part in match.groups()) if match else (-1, -1, -1)
+
+
+def get_github_file_content(branch, file_path, owner="flypipe", repo="sparkleframe", token=None):
     """
     Fetches the content of a file from a specific branch in a GitHub repo.
 
@@ -11,13 +21,18 @@ def get_github_file_content(branch, file_path, owner="flypipe", repo="sparklefra
         repo (str): Repository name.
         branch (str): Branch name.
         file_path (str): Path to the file within the repo.
-        token (str, optional): GitHub personal access token for private repos or higher rate limits.
+        token (str, optional): GitHub token for authenticated requests (higher rate limits and
+            access to private repos). Falls back to the ``GITHUB_TOKEN`` environment variable
+            when not provided.
 
     Returns:
         str: Content of the file as a string.
     """
     url = (f"https://api.github.com/repos/{owner}/{repo}/contents/{file_path}")
     headers = {'Accept': 'application/vnd.github.v3+json'}
+    token = token or os.environ.get('GITHUB_TOKEN')
+    if token:
+        headers['Authorization'] = f'Bearer {token}'
     params = {'ref': branch}
     response = requests.get(url, headers=headers, params=params)
     if response.status_code == 200:
@@ -34,10 +49,10 @@ def get_release_branches():
         .split()
     )
     release_branches = [
-        branch for branch in all_branches if branch.startswith("origin/release/")
+        branch for branch in all_branches if RELEASE_BRANCH_RE.match(branch)
     ]
 
-    return sorted(release_branches)
+    return sorted(release_branches, key=_release_version_key)[-10:]
 
 def get_commit_list(from_branch=None, to_branch=None):
     to_branch=to_branch or "HEAD"
@@ -64,7 +79,7 @@ def get_commit_message(commit_id):
 def get_changelog_latest_branch_release():
     release_branches = get_release_branches()
     if release_branches:
-        latest_version_branch_name = max(release_branches)
+        latest_version_branch_name = release_branches[-1]
         lines = get_github_file_content(latest_version_branch_name.replace("origin/", ""), "changelog.md", owner="flypipe", repo="sparkleframe")
         lines = lines.splitlines()[2:]
         lines = [l for l in lines if l.strip() != ""]


### PR DESCRIPTION
## Summary

The `Changelog (preview)` step in `verification.yml` (and the equivalent step in `prepare-deployment.yml`) has been failing with:

```
Exception: Failed to fetch file: 403 {"message":"API rate limit exceeded for 20.115.146.231. (But here's the good news: Authenticated requests get a higher rate limit. ...)"}
```

Root cause: `scripts/utils.py::get_github_file_content` was the only call site that hit `api.github.com` **unauthenticated**, so it tripped the 60 req/hr limit on the shared GitHub Actions runner IP. Everything else in `generate_changelog.py` (`git_get`) already uses `GITHUB_TOKEN`.

While in there I also fixed two latent bugs:
- `get_release_branches()` returned every release branch ever, so the more releases we cut, the more API/git work the changelog step would do.
- Release branches were sorted lexicographically. It works today (everything is single-digit), but as soon as a minor or patch component hits 10+, `0.10.0` would silently land between `0.1.0` and `0.2.0`, and `max(release_branches)` would pick the wrong "latest".

## Changes

- `scripts/utils.py`
  - `get_github_file_content` now forwards a `Bearer` token, falling back to `os.environ["GITHUB_TOKEN"]` when not passed explicitly. Raises the limit from 60 → 5000 req/hr.
  - `get_release_branches` filters via a `^origin/release/\d+\.\d+\.\d+$` regex, sorts by the parsed `(major, minor, patch)` tuple, and caps to the last 10 entries.
  - `get_changelog_latest_branch_release` now uses `release_branches[-1]` instead of `max(release_branches)`.
- `scripts/calculate_version.py` and `scripts/generate_changelog.py`: same `max() -> [-1]` swap so they rely on the semver-aware sort.

Both workflows that run the script already export `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}`, so no workflow changes are needed.

## Test plan

- [x] All 32 existing tests pass locally (`scripts/utils_test.py`, `scripts/generate_changelog_test.py`, `scripts/calculate_version_test.py`)
- [x] `get_release_branches()` returns the latest 10, ending in `origin/release/1.1.0` (current highest semver)
- [ ] CI's `Changelog (preview)` step turns green on this PR

Made with [Cursor](https://cursor.com)