### PR TITLE
feat(python): build → analyze → evaluate engine + first slice

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,9 +10,10 @@ SparkleFrame implements the **PySpark DataFrame API** so pipelines run **without
 cluster**. It is a **partial shim** targeting the **PySpark / Apache Spark 4.x** DataFrame API:
 not every operation is supported, but behavior matches Spark where implemented.
 
-It runs on a **pluggable engine**. Polars is the engine today (`sparkleframe/polarsdf`); a
-pure-Python engine is scaffolded (`sparkleframe/python`, #102). The engine is selected via the
-`Engine` enum and bound by `activate()`. See [ARCHITECTURE.md](ARCHITECTURE.md) for the map.
+It runs on a **pluggable engine**. Polars is the mature engine (`sparkleframe/polarsdf`); a
+pure-Python engine is scaffolded and landing incrementally (`sparkleframe/python`, #102) via its
+build → analyze → evaluate flow. The engine is selected via the `Engine` enum and bound by
+`activate()`. See [ARCHITECTURE.md](ARCHITECTURE.md) for the map.
 
 ## Hard invariants (always true — don't violate without explicit instruction)
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -30,25 +30,34 @@ is the scoped form. Users can also import an engine package directly and skip ac
 
 ### An engine package — the API surface
 
-An engine lives under `sparkleframe/<engine>/`. Polars is the only one implemented today
-(`sparkleframe/polarsdf`); `sparkleframe/python` is scaffolded (#102). Within a package, the public
+An engine lives under `sparkleframe/<engine>/`. Polars is the mature engine
+(`sparkleframe/polarsdf`); `sparkleframe/python` is scaffolded and landing incrementally (#102).
+Within a package, the public
 modules are **thin facades** and all real logic sits in a matching `*_helpers.py`. That split is
 an invariant, not a style preference (see Invariants below).
 
-| File (in `sparkleframe/polarsdf/`) | Responsibility |
+Both engines share this layout (`<engine>` is `polarsdf` or `python`):
+
+| File (in `sparkleframe/<engine>/`) | Responsibility |
 |---|---|
 | `__init__.py` | Exports `Column`, `DataFrame`, `SparkSession`, `Window`, `WindowSpec`, `functions` |
 | `session.py` | `SparkSession` — builder + `createDataFrame`; the entry point |
-| `dataframe.py` | `DataFrame` — wraps one engine frame; `select`/`filter`/`join`/`groupBy`/… |
-| `dataframe_helpers.py` | Join mapping, expression-join execution, value conversion |
+| `dataframe.py` | `DataFrame` — wraps the engine frame; `select`/`filter`/`join`/`groupBy`/… |
+| `dataframe_helpers.py` | Shared frame logic — join mapping, value/row conversion |
 | `column.py` | `Column` — wraps one engine expression; arithmetic, comparison, cast, getItem |
 | `column_helpers.py` | Type validation/coercion, comparison guards, strict/lenient cast helpers |
 | `functions.py` | `pyspark.sql.functions` surface (`col`, `lit`, `to_timestamp`, `element_at`, …) |
 | `functions_helpers.py` | Date/time parsing, JSON/struct, array/map helpers — each with a `strict` flag |
 | `group.py` | `GroupedData` — aggregations after `groupBy` |
 | `window.py` | `Window` / `WindowSpec` — partition/order/frame for `over()` |
-| `types.py` | DataType hierarchy + `StructType`/`ArrayType`/`MapType` and name↔type registry |
-| `types_utils.py` | Map↔Struct materialization, schema-cast application |
+| `types.py` | DataType handling — Polars keeps a name↔type registry; Python consumes PySpark types directly |
+
+Engine-specific additions:
+
+- **`polarsdf/`** adds `types_utils.py` (Map↔Struct materialization, schema-cast application).
+- **`python/`** adds `_errors.py` (the uniform `not_implemented_yet`) and the **`ast/`** package —
+  `expressions.py` (unresolved build nodes), `analyzer.py`, `evaluator.py`, `coercion.py` — which
+  implements the build → analyze → evaluate flow described below.
 
 `sparkleframe/base/dataframe.py` holds the engine-independent `DataFrame` base (e.g.
 `to_native_df`).
@@ -56,11 +65,30 @@ an invariant, not a style preference (see Invariants below).
 ### How a call flows
 
 `Column` wraps a **single** engine expression; `DataFrame` wraps a **single** engine frame. A
-PySpark call like `col("a") + col("b")` builds a `Column` around the engine's expression; the
-public operator delegates to a `column_helpers` routine that applies Spark's type rules, and the
-result is evaluated when the `DataFrame` operation (`select`/`filter`/`withColumn`) runs. This
-wrapper pair is the **seam where Spark semantics meet engine primitives** — it is where Spark
-coercion and ANSI-strictness are imposed on top of the underlying engine.
+PySpark call like `col("a") + col("b")` builds a `Column` around the engine's expression. This
+wrapper pair is the **seam where Spark semantics meet engine primitives** — where Spark coercion
+and ANSI-strictness are imposed on top of the underlying engine. The two engines sit that seam at
+different times: the **Polars** engine resolves types at *expression-build time* (the public
+operator delegates to a `column_helpers` routine immediately), evaluating when the `DataFrame`
+operation runs; the **Python** engine splits the work into three phases (below).
+
+### The Python engine — build → analyze → evaluate
+
+The `python` engine mirrors Spark's Catalyst flow instead of resolving types eagerly. Its `ast/`
+package carries the three phases:
+
+1. **Build** — constructing `col("a") + col("b")` produces an *unresolved* node
+   (`ast/expressions.py`); zero type decisions, no schema needed.
+2. **Analyze** (`ast/analyzer.py`, `ast/coercion.py`) — when the expression meets a schema-bearing
+   `DataFrame`, the tree is resolved against that `StructType`: each node's `data_type` is filled
+   and Spark coercion `Cast` nodes are inserted (e.g. `numeric + string` → cast the string to
+   double). Because the schema is in hand here, the build-time "dtype unknown" limitation behind
+   most of `docs/known_gaps.md` **cannot occur** — that is the engine's reason to exist.
+3. **Evaluate** (`ast/evaluator.py`) — run the resolved tree over the rows.
+
+Today a transform analyzes then evaluates immediately; *when* `evaluate` fires relative to building
+a transform chain (an eager-vs-lazy flag) is a `DataFrame`-layer decision noted but not yet built.
+Detail and decisions live in `docs/design/python-engine-ast.md`.
 
 ### The parity harness — proving it matches Spark
 
@@ -85,7 +113,7 @@ flowchart TD
     user["user code: import pyspark.sql / sparkleframe.&lt;engine&gt;"]
     activate["activate.py — rebinds sys.modules to the chosen engine"]
     engineenum["engine.py — Engine enum (POLARS, PYTHON)"]
-    pkg["sparkleframe/&lt;engine&gt;/ (polarsdf today, python scaffolded)"]
+    pkg["sparkleframe/&lt;engine&gt;/ (polarsdf mature, python landing)"]
     facade["public facades: functions.py / column.py / dataframe.py"]
     helpers["*_helpers.py — coercion, parsing, strict/lenient logic"]
     prim["engine primitives (Column wraps one expr, DataFrame one frame)"]
@@ -124,9 +152,10 @@ flowchart TD
   at *expression-build time*, before the frame schema is known. Cross-type coercion (e.g.
   `col(float) + col(string)`) therefore can't fire for bare column references, which is the root
   cause behind most of `docs/known_gaps.md`. Engines are free to resolve types differently behind
-  the `EngineAdapter` / `Engine` boundary. The scaffolded `python` engine resolves this differently —
-  see `docs/design/python-engine-ast.md` and #104. (No design detail here, by intent.)
-- **Multiple engines.** The canonical name for the scaffolded pure-Python engine is **`python`**
+  the `EngineAdapter` / `Engine` boundary. The `python` engine resolves this differently — it
+  resolves types in an analyze phase once the schema is known, so the `numeric + string` coercion
+  fires where Polars can't — see `docs/design/python-engine-ast.md` and #104.
+- **Multiple engines.** The canonical name for the pure-Python engine is **`python`**
   (package `sparkleframe/python/`), consistent across `engine.py`, `gaps.py`, and the docs
   generator. Note: issues #102/#104 and the `feature/pythondf-backend` branch use `pythondf`; those
   external references should be reconciled to `python`.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 SparkleFrame implements the PySpark DataFrame API so you can run transformation pipelines on a lightweight
 **engine** instead of a Spark cluster—no Spark cluster or Spark dependencies required. The engine is pluggable:
-[Polars](https://docs.pola.rs/api/python/stable/reference/index.html) today, with a pure-Python engine scaffolded.
+[Polars](https://docs.pola.rs/api/python/stable/reference/index.html) today, with a pure-Python engine in development.
 It is a **partial** **shim** aimed at the **PySpark / Apache Spark 4.x** DataFrame API: not every operation or
 edge case is supported, but behavior matches Spark where implemented.
 

--- a/docs/contributing/engines.md
+++ b/docs/contributing/engines.md
@@ -22,8 +22,10 @@ class Engine(Enum):
 rebinds `sys.modules["pyspark.sql"]` (and submodules) to it, so existing `import pyspark` code runs
 on the engine. Selecting an engine that isn't scaffolded raises `NotImplementedError`.
 
-Only the **Polars** engine (`sparkleframe/polarsdf`) is implemented today. The **`python`** engine
-(`sparkleframe/python`) is scaffolded — see [#102](https://github.com/flypipe/sparkleframe/issues/102)
+The **Polars** engine (`sparkleframe/polarsdf`) is the mature engine. The **`python`** engine
+(`sparkleframe/python`) is scaffolded and landing incrementally via its build → analyze → evaluate
+flow — the first vertical slice (numeric arithmetic, incl. the `numeric + string` coercion) is in,
+and its gate drains as more behaviors land. See [#102](https://github.com/flypipe/sparkleframe/issues/102)
 and the design in [../design/python-engine-ast.md](../design/python-engine-ast.md).
 
 ## The parity harness
@@ -46,11 +48,11 @@ support yet**:
 
 ```python
 POLARS_NOT_SUPPORTED = { "arithmetic.numeric_plus_string", ... }
-PYTHON_NOT_IMPLEMENTED = { ...everything, while the engine is empty... }
+PYTHON_NOT_IMPLEMENTED = { ...behaviors not yet drained as the engine lands... }
 
 GATES = {"polars": POLARS_NOT_SUPPORTED, "python": PYTHON_NOT_IMPLEMENTED}
 
-PYTHON_GATE_HIGH_WATER_MARK = 167   # committed high-water mark; only ever lowered
+PYTHON_GATE_HIGH_WATER_MARK = 165   # committed high-water mark; only ever lowered
 ```
 
 A parity test tagged `@pytest.mark.feature("<id>")` is `xfail`ed for an engine when `<id>` is in that

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -106,6 +106,113 @@ spark_result = spark_mixed.select(spark_try_to_timestamp("ts").alias("result"))
 assert_matches_spark(sf_result, spark_result, ENGINES[Engine.POLARS])
 ```
 
+## Test layering: who owns what
+
+SparkleFrame has five overlapping test layers. Each layer owns a *different property* of the
+same code. When writing a new test, decide which layer should own the assertion and resist
+restating it elsewhere — duplicated assertions add maintenance cost without adding signal.
+
+| Layer | Lives in | Owns |
+|---|---|---|
+| AST phase units | `sparkleframe/python/ast/*_test.py` | What a single phase produces: coercion table, analyze inserts `Cast`, evaluate computes values from a resolved tree. Pure functions; no DataFrame. |
+| Engine parity | `sparkleframe/tests/parity/` | Result *values* match real Spark across `[POLARS]` and `[PYTHON]`. The oracle compares records as a sorted multiset and does **not** assert schema/dtypes. |
+| Colocated DataFrame units | `sparkleframe/<engine>/dataframe_test.py` | Orchestration contract for the DataFrame surface: projection, output order, output names, *resolved output dtype*, argument handling, unimplemented-slot raising. **Not values** — parity owns those. |
+| Colocated Column units | `sparkleframe/<engine>/column_test.py` | AST shape produced by dunder methods: which node type, which operator string, which operand is on which side (especially for reflected ops). |
+| Colocated functions units | `sparkleframe/<engine>/functions_test.py` | AST shape produced by each `F.*` factory: node type, name, arg structure, branch order for `when/otherwise`. |
+
+The shorthand: **parity owns values; colocated units own structure.** If a colocated test
+asserts a numeric result that parity already covers, either delete the assertion or replace it
+with the structural property it was implicitly probing (typically: output schema/dtype).
+
+## Smells to avoid in colocated tests
+
+These are the common smells that have shown up in review. Fix them at write-time, not at
+review-time.
+
+### 1. Re-asserting values that parity already covers
+
+```python
+# BAD — parity already proves 11/22 against real Spark; this is strictly weaker.
+out = df.select((F.col("a") + F.col("b")).alias("r"))
+assert out.to_records() == [{"r": 11}, {"r": 22}]
+```
+
+If the only unique thing the test proves is the resolved dtype, keep just that and drop the
+value assertion:
+
+```python
+# GOOD — parity owns the value; this owns the schema/dtype claim parity ignores.
+out = df.select((F.col("i") + F.col("l")).alias("r"))
+assert isinstance(out._schema["r"].dataType, LongType)
+```
+
+### 2. Fixtures that can't fail the property
+
+```python
+# BAD — single-column input; ``select("a")`` passes even if select ignored its arg.
+df = DataFrame([(1,), (2,)], StructType([StructField("a", IntegerType())]))
+assert df.select("a").to_records() == [{"a": 1}, {"a": 2}]
+```
+
+A test must use a fixture that lets the property fail. For projection, that means **≥2
+columns**; for ordering, distinct names; for dtype resolution, operands whose result type
+differs from the inputs.
+
+### 3. Mocking AST phases ("did analyze run?")
+
+```python
+# BAD — couples to call structure; passes even if the frame is assembled wrong.
+with patch("sparkleframe.python.ast.analyzer.analyze") as m:
+    df.select(F.col("a") + F.col("b"))
+    m.assert_called_once()
+```
+
+A behavioral assertion on the output (schema + records, or resolved dtype) already proves
+analyze fired *and* checks the contract. Mocks here lock in implementation details and bypass
+the actual property under test.
+
+### 4. Import-smoke tests
+
+```python
+# BAD — passes whenever the module exists; zero information.
+def test_helpers_module_importable():
+    assert isinstance(helpers.__name__, str)
+```
+
+Trust the import system. If you need a single canary that the package layout is intact, write
+**one** dedicated test, not one per submodule.
+
+### 5. Runtime "type" assertions that duplicate mypy
+
+```python
+# BAD — mypy and ruff catch this in CI.
+assert isinstance(out, DataFrame)
+```
+
+The meaningful runtime analog is asserting the resolved output `StructField` dtype, which mypy
+*can't* see.
+
+### 6. Reflected-operator tests that only check the operator
+
+```python
+# BAD — passes even if ``__rsub__`` swaps operands.
+result = 1 - c
+assert result._expr.op == "-"
+```
+
+Non-commutative reflected dunders (`__rsub__`, `__rtruediv__`, `__rpow__`) must also assert
+operand placement — otherwise a left/right swap regression slips through.
+
+### 7. Substring repr smoke tests
+
+```python
+# BAD — passes for any repr that contains the class name.
+assert "Column(" in repr(col)
+```
+
+Either assert the repr *delegates* (contains the wrapped name/expression), or delete the test.
+"Class name appears in its own repr" is a tautology.
+
 ## Parity-test conventions
 
 The shared parity suite (`sparkleframe/tests/parity/`) runs each test against **every engine**.

--- a/docs/design/python-engine-ast.md
+++ b/docs/design/python-engine-ast.md
@@ -1,9 +1,10 @@
 # Design: AST-based type resolution for the Python engine
 
-> This describes a design for the scaffolded pure-Python engine (`sparkleframe/python`,
-> [#102](https://github.com/flypipe/sparkleframe/issues/102)). It is forward-looking and
-> will change as the engine lands. It is intentionally kept out of `ARCHITECTURE.md`, which
-> maps what exists today. Tracking issue: [#104](https://github.com/flypipe/sparkleframe/issues/104).
+> This describes the design for the pure-Python engine (`sparkleframe/python`,
+> [#102](https://github.com/flypipe/sparkleframe/issues/102)). The first vertical slice has landed
+> (see "Resolved decisions" below); the rest is forward-looking and will change as the engine lands.
+> It is intentionally kept out of `ARCHITECTURE.md`, which maps the coarse pieces. Tracking issue:
+> [#104](https://github.com/flypipe/sparkleframe/issues/104).
 
 ## The problem
 
@@ -47,6 +48,30 @@ by case.
 This is also the Python engine's path to **draining `PYTHON_NOT_IMPLEMENTED`**: each behavior the
 analyze/evaluate phases correctly reproduce lets its feature id be removed from the gate (see
 [engines.md](../contributing/engines.md) for the ratchet workflow).
+
+## Resolved decisions (#104)
+
+The first vertical slice (build → analyze → evaluate for numeric `+ - *`, including the
+`numeric + string` coercion Polars cannot do) settled the open questions from #104:
+
+- **Q1 — resolve against the declared schema.** The analyzer resolves types against the frame's
+  PySpark `StructType`, not against row values. Operations follow the current frame schema.
+- **Q2 — dtype only on resolved nodes.** A resolved node carries its `data_type` and nothing
+  else; nullability/metadata are deferred until an API needs them.
+- **Q3 — "evaluate inside analyze" is a DataFrame-layer concern, not an expression one.** The
+  *expression* analyze phase is pure type resolution: schema in, typed tree out, **no data and no
+  evaluate triggered**. When `evaluate` actually fires (eagerly as a `select`/`filter` chain is
+  built, or lazily at an action) is the DataFrame eager-vs-lazy question. We record the intent of
+  a forward `EAGER`/`LAZY` flag on the DataFrame layer but **do not build it yet**; today
+  `select` analyzes then evaluates immediately, and `analyze` never calls `evaluate`.
+- **Q4 — coercion rewritten cleanly over PySpark types.** `ast/coercion.py` re-derives Spark's
+  rules (numeric widening rank, `numeric + string` → cast string to double) from scratch; it does
+  not port `polarsdf` internals.
+
+**Resolved form — reuse the existing nodes.** `analyze(expr, schema)` returns a *new* tree of the
+same `Expression` classes with each node's `.data_type` slot filled and coercion `Cast` nodes
+inserted where Spark would; the original build tree is left untouched. "Typed" means every
+returned node has `data_type is not None`. The evaluator then walks that resolved tree.
 
 ## Scope notes
 

--- a/docs/known_gaps.md
+++ b/docs/known_gaps.md
@@ -4,6 +4,12 @@ SparkleFrame aims to match PySpark / Spark 4.x behaviour, but some edge cases
 are not yet supported.  This page lists the known gaps so contributors can
 prioritise fixes and users can work around them.
 
+> These gaps are specific to the **Polars** engine, whose root cause is build-time
+> type resolution (see "Mixed-type column arithmetic" below). The pure-Python engine
+> (`sparkleframe/python`, #102) resolves types in an *analyze* phase once the schema is
+> known, which removes this whole class structurally — it already handles
+> `Numeric + String`. See [design/python-engine-ast.md](design/python-engine-ast.md).
+
 ## Mixed-type column arithmetic
 
 **Affected operations:** `+`, `-`, `*`, `/` between two columns of different

--- a/sparkleframe/python/_errors.py
+++ b/sparkleframe/python/_errors.py
@@ -1,9 +1,9 @@
 """Shared 'not implemented yet' helper for the pure-Python engine scaffolding.
 
-The engine is a walking skeleton: the public surface (functions, Column, DataFrame, …) is
-declared, but every operation raises — the build, analyze, and evaluate phases all land with the
-engine itself. Use this helper so the message is consistent and always points a future
-implementer at the design doc and the build → analyze → evaluate flow.
+The engine is a walking skeleton: the build phase (constructing the expression AST) is wired,
+but the analyze and evaluate phases — and every DataFrame action — raise. Use this helper so
+the message is consistent and always points a future implementer at the design doc and the
+build → analyze → evaluate flow.
 """
 
 from __future__ import annotations

--- a/sparkleframe/python/ast/__init__.py
+++ b/sparkleframe/python/ast/__init__.py
@@ -1,0 +1,38 @@
+"""The AST core of the pure-Python engine: build → analyze → evaluate.
+
+This sub-package is the engine's heart, kept separate from the public API surface
+(``column``/``functions``/``dataframe``). It holds the unresolved expression nodes produced by
+the **build** phase (:mod:`~sparkleframe.python.ast.expressions`), the **analyze** phase that
+resolves types against a schema (:mod:`~sparkleframe.python.ast.analyzer`), and the
+**evaluate** phase that runs a resolved expression (:mod:`~sparkleframe.python.ast.evaluator`).
+See ``docs/design/python-engine-ast.md``.
+"""
+
+# ruff: noqa: F401
+from sparkleframe.python.ast.analyzer import analyze
+from sparkleframe.python.ast.evaluator import evaluate
+from sparkleframe.python.ast.expressions import (
+    Alias,
+    AttributeReference,
+    BinaryExpression,
+    CaseWhen,
+    Cast,
+    Expression,
+    FunctionCall,
+    Literal,
+    UnaryExpression,
+)
+
+__all__ = [
+    "analyze",
+    "evaluate",
+    "Alias",
+    "AttributeReference",
+    "BinaryExpression",
+    "CaseWhen",
+    "Cast",
+    "Expression",
+    "FunctionCall",
+    "Literal",
+    "UnaryExpression",
+]

--- a/sparkleframe/python/ast/analyzer.py
+++ b/sparkleframe/python/ast/analyzer.py
@@ -1,0 +1,80 @@
+"""Analyze phase: resolve an unresolved :class:`~sparkleframe.python.ast.expressions.Expression`
+against a schema.
+
+This is the middle phase of build → analyze → evaluate (see ``docs/design/python-engine-ast.md``).
+Because resolution happens *here* — where the schema is in hand — the "dtype unknown at build
+time" state that limits the Polars engine cannot occur.
+
+:func:`analyze` walks the unresolved tree and returns a **new** tree of the same node classes
+with each node's ``data_type`` slot filled and coercion :class:`Cast` nodes inserted where Spark
+would. The original build tree is left untouched; "resolved" means every returned node has
+``data_type is not None``.
+
+This is the seam where per-feature type resolution lands. Implementing a feature here (plus
+:mod:`sparkleframe.python.ast.evaluator`) is what lets its id be deleted from
+``PYTHON_NOT_IMPLEMENTED`` in ``sparkleframe/tests/parity/gaps.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sparkleframe.python._errors import not_implemented_yet
+from sparkleframe.python.ast import coercion
+from sparkleframe.python.ast.expressions import (
+    Alias,
+    AttributeReference,
+    BinaryExpression,
+    Cast,
+    Expression,
+    Literal,
+)
+
+
+def analyze(expr: Expression, schema: Any) -> Expression:
+    """Resolve ``expr``'s output types against ``schema`` and return the resolved tree.
+
+    Args:
+        expr: The unresolved expression produced by the build phase.
+        schema: The PySpark ``StructType`` of the frame the expression is applied to.
+    """
+    if isinstance(expr, AttributeReference):
+        resolved = AttributeReference(expr.name)
+        resolved.data_type = _field_type(schema, expr.name)
+        return resolved
+
+    if isinstance(expr, Literal):
+        return Literal(expr.value, data_type=expr.data_type or coercion.infer_literal_type(expr.value))
+
+    if isinstance(expr, Alias):
+        child = analyze(expr.child, schema)
+        resolved = Alias(child, expr.name)
+        resolved.data_type = child.data_type
+        return resolved
+
+    if isinstance(expr, BinaryExpression) and expr.op in ("+", "-", "*"):
+        left = analyze(expr.left, schema)
+        right = analyze(expr.right, schema)
+        result_dt, left_cast, right_cast = coercion.coerce_arithmetic(expr.op, left.data_type, right.data_type)
+        resolved = BinaryExpression(expr.op, _with_cast(left, left_cast), _with_cast(right, right_cast))
+        resolved.data_type = result_dt
+        return resolved
+
+    detail = f"{type(expr).__name__} {getattr(expr, 'op', '')}".strip()
+    not_implemented_yet(f"the analyze phase for {detail}")
+
+
+def _with_cast(resolved: Expression, target_dt: Any) -> Expression:
+    """Wrap ``resolved`` in a strict :class:`Cast` to ``target_dt`` (or return it unchanged)."""
+    if target_dt is None:
+        return resolved
+    cast = Cast(resolved, target_dt, strict=True)
+    cast.data_type = target_dt
+    return cast
+
+
+def _field_type(schema: Any, name: str) -> Any:
+    """Look up a column's declared PySpark ``DataType`` in the frame schema."""
+    if schema is None:
+        raise KeyError(f"Cannot resolve column {name!r}: no schema in hand")
+    return schema[name].dataType

--- a/sparkleframe/python/ast/analyzer_test.py
+++ b/sparkleframe/python/ast/analyzer_test.py
@@ -1,0 +1,87 @@
+"""Unit tests for the analyze phase: type resolution + coercion-cast insertion."""
+
+import pytest
+from pyspark.sql.types import (
+    DoubleType,
+    IntegerType,
+    LongType,
+    StringType,
+    StructField,
+    StructType,
+)
+
+from sparkleframe.python.ast.analyzer import analyze
+from sparkleframe.python.ast.expressions import (
+    Alias,
+    AttributeReference,
+    BinaryExpression,
+    Cast,
+    Literal,
+    UnaryExpression,
+)
+
+
+def _schema(*fields):
+    return StructType([StructField(name, dtype) for name, dtype in fields])
+
+
+class TestResolvesTypes:
+    def test_attribute_reference_from_schema(self):
+        resolved = analyze(AttributeReference("a"), _schema(("a", IntegerType())))
+        assert isinstance(resolved, AttributeReference)
+        assert isinstance(resolved.data_type, IntegerType)
+
+    def test_literal_inferred(self):
+        resolved = analyze(Literal(3.14), schema=None)
+        assert isinstance(resolved.data_type, DoubleType)
+
+    def test_alias_carries_name_and_child_type(self):
+        expr = Alias(AttributeReference("a"), "renamed")
+        resolved = analyze(expr, _schema(("a", IntegerType())))
+        assert isinstance(resolved, Alias)
+        assert resolved.name == "renamed"
+        assert isinstance(resolved.data_type, IntegerType)
+
+    def test_col_plus_col_same_type_no_cast(self):
+        expr = BinaryExpression("+", AttributeReference("a"), AttributeReference("b"))
+        resolved = analyze(expr, _schema(("a", IntegerType()), ("b", IntegerType())))
+        assert isinstance(resolved.data_type, IntegerType)
+        assert not isinstance(resolved.left, Cast)
+        assert not isinstance(resolved.right, Cast)
+
+    def test_col_plus_col_widening_inserts_cast(self):
+        expr = BinaryExpression("+", AttributeReference("a"), AttributeReference("b"))
+        resolved = analyze(expr, _schema(("a", IntegerType()), ("b", LongType())))
+        assert isinstance(resolved.data_type, LongType)
+        assert isinstance(resolved.left, Cast)
+        assert isinstance(resolved.left.data_type, LongType)
+        assert not isinstance(resolved.right, Cast)
+
+    def test_double_plus_string_casts_string_side(self):
+        expr = BinaryExpression("+", AttributeReference("d"), AttributeReference("s"))
+        resolved = analyze(expr, _schema(("d", DoubleType()), ("s", StringType())))
+        assert isinstance(resolved.data_type, DoubleType)
+        assert not isinstance(resolved.left, Cast)
+        assert isinstance(resolved.right, Cast)
+        assert isinstance(resolved.right.data_type, DoubleType)
+
+    def test_col_plus_lit(self):
+        expr = BinaryExpression("+", AttributeReference("a"), Literal(1))
+        resolved = analyze(expr, _schema(("a", IntegerType())))
+        assert isinstance(resolved.data_type, IntegerType)
+
+    def test_original_tree_untouched(self):
+        expr = AttributeReference("a")
+        analyze(expr, _schema(("a", IntegerType())))
+        assert expr.data_type is None
+
+
+class TestUnsupportedRaises:
+    def test_unsupported_node_raises(self):
+        with pytest.raises(NotImplementedError):
+            analyze(UnaryExpression("neg", AttributeReference("a")), _schema(("a", IntegerType())))
+
+    def test_unsupported_operator_raises(self):
+        expr = BinaryExpression("/", AttributeReference("a"), AttributeReference("b"))
+        with pytest.raises(NotImplementedError):
+            analyze(expr, _schema(("a", IntegerType()), ("b", IntegerType())))

--- a/sparkleframe/python/ast/coercion.py
+++ b/sparkleframe/python/ast/coercion.py
@@ -1,0 +1,120 @@
+"""Spark type-coercion rules for the **analyze** phase, written over PySpark types.
+
+These are pure functions: given the resolved ``data_type`` of an operand (a PySpark
+``DataType``), they decide the result type of an operation and where Spark would insert an
+implicit cast. They are a clean rewrite of the coercion behavior Spark documents — they do
+**not** port ``polarsdf`` internals (per #104 Q4).
+
+The ``pyspark.sql.types`` import is guarded exactly like
+:mod:`sparkleframe.python.types`: under ``activate()`` the real ``pyspark`` package is replaced
+by a mock that has no real types, but these functions only run at analyze time (under real
+pyspark), so referencing the type classes inside them is safe.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional, Tuple
+
+from sparkleframe.python._errors import not_implemented_yet
+
+try:  # pragma: no cover - exercised only with the real pyspark installed
+    from pyspark.sql.types import (
+        BooleanType,
+        ByteType,
+        DoubleType,
+        FloatType,
+        IntegerType,
+        LongType,
+        NullType,
+        ShortType,
+        StringType,
+    )
+except Exception:  # pragma: no cover - mock pyspark (under activate) has no real types
+    pass
+
+
+def _numeric_rank(dtype: Any) -> int:
+    """Spark numeric widening rank: ``Byte < Short < Int < Long < Float < Double``."""
+    order = (ByteType, ShortType, IntegerType, LongType, FloatType, DoubleType)
+    for rank, cls in enumerate(order):
+        if isinstance(dtype, cls):
+            return rank
+    raise ValueError(f"{type(dtype).__name__} is not a numeric type")
+
+
+def is_numeric(dtype: Any) -> bool:
+    """Whether ``dtype`` is one of the numeric types this slice widens over."""
+    return isinstance(dtype, (ByteType, ShortType, IntegerType, LongType, FloatType, DoubleType))
+
+
+def is_string(dtype: Any) -> bool:
+    return isinstance(dtype, StringType)
+
+
+def widen_numeric(left: Any, right: Any) -> Any:
+    """Return the higher-ranked of two numeric types (the common widened type).
+
+    Same type in → same type out (``int + int -> int``).
+    """
+    return left if _numeric_rank(left) >= _numeric_rank(right) else right
+
+
+def _is_integral(dtype: Any) -> bool:
+    """Whether ``dtype`` is one of Spark's integral types (Byte/Short/Int/Long)."""
+    return isinstance(dtype, (ByteType, ShortType, IntegerType, LongType))
+
+
+def _string_arith_promote_type(numeric_dt: Any) -> Any:
+    """Type the string operand (and numeric operand) is cast to in ``numeric <op> string``.
+
+    Spark 4 ANSI promotes the string to ``long`` when the numeric operand is integral
+    (``byte/short/int/long`` all widen to ``long``) and to ``double`` when it is floating
+    (``float`` widens to ``double``).
+    """
+    return LongType() if _is_integral(numeric_dt) else DoubleType()
+
+
+def infer_literal_type(value: Any) -> Any:
+    """Infer the PySpark type of a Python literal (minimal set this slice needs)."""
+    if value is None:
+        return NullType()
+    # ``bool`` is a subclass of ``int`` — check it first.
+    if isinstance(value, bool):
+        return BooleanType()
+    if isinstance(value, int):
+        # Spark widens an out-of-int32-range literal to bigint.
+        return IntegerType() if -(2**31) <= value < 2**31 else LongType()
+    if isinstance(value, float):
+        return DoubleType()
+    if isinstance(value, str):
+        return StringType()
+    not_implemented_yet(f"literal type inference for {type(value).__name__}")
+
+
+def coerce_arithmetic(op: str, left_dt: Any, right_dt: Any) -> Tuple[Any, Optional[Any], Optional[Any]]:
+    """Resolve the result type (and any operand casts) of ``left <op> right``.
+
+    Returns ``(result_dt, left_cast_dt, right_cast_dt)`` where a ``*_cast_dt`` is the type the
+    corresponding operand must be cast to (or ``None`` if no cast is needed). Only ``+ - *`` are
+    supported in this slice — ``/`` and ``**`` result types are out of scope and raise.
+    """
+    if op not in ("+", "-", "*"):
+        not_implemented_yet(f"arithmetic result type for operator {op!r}")
+
+    if is_numeric(left_dt) and is_numeric(right_dt):
+        result = widen_numeric(left_dt, right_dt)
+        left_cast = None if type(left_dt) is type(result) else result
+        right_cast = None if type(right_dt) is type(result) else result
+        return result, left_cast, right_cast
+
+    # numeric + string: Spark promotes the string to the numeric operand's arithmetic type —
+    # ``long`` when the numeric is integral (``int + "3" -> long``) and ``double`` when it is
+    # floating (``double + "3.14" -> double``). The numeric operand widens to that type too.
+    if is_string(left_dt) and is_numeric(right_dt):
+        result = _string_arith_promote_type(right_dt)
+        return result, result, (None if type(right_dt) is type(result) else result)
+    if is_numeric(left_dt) and is_string(right_dt):
+        result = _string_arith_promote_type(left_dt)
+        return result, (None if type(left_dt) is type(result) else result), result
+
+    not_implemented_yet(f"arithmetic coercion for {type(left_dt).__name__} {op} {type(right_dt).__name__}")

--- a/sparkleframe/python/ast/coercion_test.py
+++ b/sparkleframe/python/ast/coercion_test.py
@@ -1,0 +1,82 @@
+"""Unit tests for the analyze-phase coercion rules (over real PySpark types)."""
+
+import pytest
+from pyspark.sql.types import (
+    BooleanType,
+    DoubleType,
+    IntegerType,
+    LongType,
+    NullType,
+    StringType,
+)
+
+from sparkleframe.python.ast import coercion
+
+
+class TestWidenNumeric:
+    def test_same_type_unchanged(self):
+        assert isinstance(coercion.widen_numeric(IntegerType(), IntegerType()), IntegerType)
+
+    def test_int_and_long_widens_to_long(self):
+        assert isinstance(coercion.widen_numeric(IntegerType(), LongType()), LongType)
+        assert isinstance(coercion.widen_numeric(LongType(), IntegerType()), LongType)
+
+    def test_long_and_double_widens_to_double(self):
+        assert isinstance(coercion.widen_numeric(LongType(), DoubleType()), DoubleType)
+
+
+class TestInferLiteralType:
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            (1, IntegerType),
+            (2**40, LongType),
+            (3.14, DoubleType),
+            ("x", StringType),
+            (True, BooleanType),
+            (None, NullType),
+        ],
+    )
+    def test_infer(self, value, expected):
+        assert isinstance(coercion.infer_literal_type(value), expected)
+
+
+class TestCoerceArithmetic:
+    def test_int_plus_int_no_casts(self):
+        result, left_cast, right_cast = coercion.coerce_arithmetic("+", IntegerType(), IntegerType())
+        assert isinstance(result, IntegerType)
+        assert left_cast is None and right_cast is None
+
+    def test_int_plus_long_casts_int_operand(self):
+        result, left_cast, right_cast = coercion.coerce_arithmetic("+", IntegerType(), LongType())
+        assert isinstance(result, LongType)
+        assert isinstance(left_cast, LongType)
+        assert right_cast is None
+
+    def test_double_plus_string_casts_string_to_double(self):
+        result, left_cast, right_cast = coercion.coerce_arithmetic("+", DoubleType(), StringType())
+        assert isinstance(result, DoubleType)
+        assert left_cast is None
+        assert isinstance(right_cast, DoubleType)
+
+    def test_int_plus_string_promotes_to_long(self):
+        # An integral numeric + string promotes the string (and the numeric) to long, not double.
+        result, left_cast, right_cast = coercion.coerce_arithmetic("+", IntegerType(), StringType())
+        assert isinstance(result, LongType)
+        assert isinstance(left_cast, LongType)
+        assert isinstance(right_cast, LongType)
+
+    def test_string_plus_long_promotes_to_long(self):
+        # Long is already the promotion target, so the numeric operand needs no cast.
+        result, left_cast, right_cast = coercion.coerce_arithmetic("+", StringType(), LongType())
+        assert isinstance(result, LongType)
+        assert isinstance(left_cast, LongType)
+        assert right_cast is None
+
+    def test_unsupported_operator_raises(self):
+        with pytest.raises(NotImplementedError):
+            coercion.coerce_arithmetic("/", IntegerType(), IntegerType())
+
+    def test_unsupported_operand_types_raise(self):
+        with pytest.raises(NotImplementedError):
+            coercion.coerce_arithmetic("+", StringType(), StringType())

--- a/sparkleframe/python/ast/evaluator.py
+++ b/sparkleframe/python/ast/evaluator.py
@@ -1,0 +1,98 @@
+"""Evaluate phase: run a resolved :class:`~sparkleframe.python.ast.expressions.Expression`
+against data.
+
+This is the final phase of build → analyze → evaluate (see ``docs/design/python-engine-ast.md``).
+The evaluator consumes an expression already resolved by :mod:`sparkleframe.python.ast.analyzer`
+(so every node has a known ``data_type``) and produces the resulting column values.
+
+:func:`evaluate` works **column-wise**: given the frame's rows (as dicts) it returns one value
+per row for the expression. It dispatches on node kind plus ``op`` and computes Python values
+directly.
+
+This is the seam where per-feature execution lands. Implementing a feature here (plus
+:mod:`sparkleframe.python.ast.analyzer`) is what lets its id be deleted from
+``PYTHON_NOT_IMPLEMENTED`` in ``sparkleframe/tests/parity/gaps.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List
+
+from sparkleframe.python._errors import not_implemented_yet
+from sparkleframe.python.ast.expressions import (
+    Alias,
+    AttributeReference,
+    BinaryExpression,
+    Cast,
+    Expression,
+    Literal,
+)
+
+try:  # pragma: no cover - exercised only with the real pyspark installed
+    from pyspark.sql.types import (
+        ByteType,
+        DoubleType,
+        FloatType,
+        IntegerType,
+        LongType,
+        ShortType,
+        StringType,
+    )
+except Exception:  # pragma: no cover - mock pyspark (under activate) has no real types
+    pass
+
+
+def evaluate(expr: Expression, rows: List[dict]) -> List[Any]:
+    """Run a resolved ``expr`` against ``rows`` and return one value per row.
+
+    Args:
+        expr: An expression already resolved by :func:`sparkleframe.python.ast.analyzer.analyze`.
+        rows: The frame's rows as dicts keyed by column name.
+    """
+    if isinstance(expr, AttributeReference):
+        return [row[expr.name] for row in rows]
+
+    if isinstance(expr, Literal):
+        return [expr.value for _ in rows]
+
+    if isinstance(expr, Alias):
+        return evaluate(expr.child, rows)
+
+    if isinstance(expr, Cast):
+        return [_cast_value(v, expr.target_type) for v in evaluate(expr.child, rows)]
+
+    if isinstance(expr, BinaryExpression) and expr.op in ("+", "-", "*"):
+        left = evaluate(expr.left, rows)
+        right = evaluate(expr.right, rows)
+        return [_arithmetic(expr.op, lv, rv) for lv, rv in zip(left, right)]
+
+    detail = f"{type(expr).__name__} {getattr(expr, 'op', '')}".strip()
+    not_implemented_yet(f"the evaluate phase for {detail}")
+
+
+def _arithmetic(op: str, left: Any, right: Any) -> Any:
+    """Apply ``+ - *`` element-wise; any null operand yields null (Spark semantics)."""
+    if left is None or right is None:
+        return None
+    if op == "+":
+        return left + right
+    if op == "-":
+        return left - right
+    return left * right
+
+
+def _cast_value(value: Any, target_type: Any) -> Any:
+    """Cast a single Python value to ``target_type`` (a PySpark ``DataType``).
+
+    Covers the casts this slice inserts: string → double (via ``float``) and numeric → numeric.
+    A null stays null. ANSI-strict behavior comes for free — ``float("x")`` raises on bad input.
+    """
+    if value is None:
+        return None
+    if isinstance(target_type, (FloatType, DoubleType)):
+        return float(value)
+    if isinstance(target_type, (ByteType, ShortType, IntegerType, LongType)):
+        return int(value)
+    if isinstance(target_type, StringType):
+        return str(value)
+    not_implemented_yet(f"casting to {type(target_type).__name__}")

--- a/sparkleframe/python/ast/evaluator_test.py
+++ b/sparkleframe/python/ast/evaluator_test.py
@@ -1,0 +1,69 @@
+"""Unit tests for the evaluate phase: run resolved trees over sample rows."""
+
+import pytest
+from pyspark.sql.types import DoubleType, IntegerType, LongType, StringType, StructField, StructType
+
+from sparkleframe.python.ast.analyzer import analyze
+from sparkleframe.python.ast.evaluator import evaluate
+from sparkleframe.python.ast.expressions import (
+    Alias,
+    AttributeReference,
+    BinaryExpression,
+    Cast,
+    Literal,
+    UnaryExpression,
+)
+
+
+def _schema(*fields):
+    return StructType([StructField(name, dtype) for name, dtype in fields])
+
+
+class TestEvaluate:
+    def test_attribute_reference_reads_field(self):
+        rows = [{"a": 1}, {"a": 2}]
+        assert evaluate(AttributeReference("a"), rows) == [1, 2]
+
+    def test_literal_broadcasts(self):
+        rows = [{"a": 1}, {"a": 2}]
+        assert evaluate(Literal(7), rows) == [7, 7]
+
+    def test_col_plus_col(self):
+        rows = [{"a": 1, "b": 10}, {"a": 2, "b": 20}]
+        resolved = analyze(
+            BinaryExpression("+", AttributeReference("a"), AttributeReference("b")),
+            _schema(("a", IntegerType()), ("b", IntegerType())),
+        )
+        assert evaluate(resolved, rows) == [11, 22]
+
+    def test_alias_passthrough(self):
+        rows = [{"a": 5}]
+        assert evaluate(Alias(AttributeReference("a"), "x"), rows) == [5]
+
+    def test_cast_string_to_double(self):
+        rows = [{"s": "3.14"}, {"s": "0.5"}]
+        assert evaluate(Cast(AttributeReference("s"), DoubleType(), strict=True), rows) == [3.14, 0.5]
+
+    def test_cast_numeric_widening(self):
+        rows = [{"a": 1}, {"a": 2}]
+        assert evaluate(Cast(AttributeReference("a"), LongType(), strict=True), rows) == [1, 2]
+
+    def test_double_plus_string_resolved(self):
+        rows = [{"d": 1.0, "s": "3.14"}, {"d": 2.5, "s": "0.5"}]
+        resolved = analyze(
+            BinaryExpression("+", AttributeReference("d"), AttributeReference("s")),
+            _schema(("d", DoubleType()), ("s", StringType())),
+        )
+        assert evaluate(resolved, rows) == [pytest.approx(4.14), pytest.approx(3.0)]
+
+    def test_null_operand_yields_null(self):
+        rows = [{"a": None, "b": 1}]
+        resolved = analyze(
+            BinaryExpression("+", AttributeReference("a"), AttributeReference("b")),
+            _schema(("a", IntegerType()), ("b", IntegerType())),
+        )
+        assert evaluate(resolved, rows) == [None]
+
+    def test_unsupported_node_raises(self):
+        with pytest.raises(NotImplementedError):
+            evaluate(UnaryExpression("neg", AttributeReference("a")), [{"a": 1}])

--- a/sparkleframe/python/ast/expressions.py
+++ b/sparkleframe/python/ast/expressions.py
@@ -1,0 +1,174 @@
+"""Unresolved expression AST for the pure-Python engine — the **build** phase.
+
+This module is the backbone of the build → analyze → evaluate flow described in
+``docs/design/python-engine-ast.md``. Constructing an expression (e.g. ``col("a") + lit(1)``)
+produces an unresolved AST node here and makes **zero type decisions** — the schema is not
+known at build time. Type resolution happens later in :mod:`sparkleframe.python.ast.analyzer`
+(analyze), and execution in :mod:`sparkleframe.python.ast.evaluator` (evaluate).
+
+The node classes are deliberately generic (Catalyst-style): a small set covers the whole
+public API surface, so the analyzer and evaluator dispatch on the node kind plus an
+``op`` / ``name`` string rather than needing one class per operator or function.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional, Tuple
+
+
+class Expression:
+    """Base class for every unresolved AST node.
+
+    Pure structure: holds child sub-expressions and, after the analyze phase, an optional
+    resolved :attr:`data_type`. The **build** phase must never set :attr:`data_type` — that
+    is the analyzer's job once a schema is in hand (see the design doc).
+    """
+
+    def __init__(self, children: Optional[List["Expression"]] = None) -> None:
+        self.children: List[Expression] = list(children) if children else []
+        # Filled in by analyzer.analyze(); ``None`` means "not resolved yet".
+        self.data_type: Any = None
+
+    def __repr__(self) -> str:
+        inner = ", ".join(repr(c) for c in self.children)
+        return f"{type(self).__name__}({inner})"
+
+
+class Literal(Expression):
+    """A constant, e.g. ``lit(1)`` or ``lit(None)``."""
+
+    def __init__(self, value: Any, data_type: Any = None) -> None:
+        super().__init__()
+        self.value = value
+        # A literal's type may be supplied at build time (e.g. a typed null); otherwise the
+        # analyzer infers it from ``value``.
+        self.data_type = data_type
+
+    def __repr__(self) -> str:
+        return f"Literal({self.value!r})"
+
+
+class AttributeReference(Expression):
+    """An unresolved column reference, e.g. ``col("x")``."""
+
+    def __init__(self, name: str) -> None:
+        super().__init__()
+        self.name = name
+
+    def __repr__(self) -> str:
+        return f"AttributeReference({self.name!r})"
+
+
+class BinaryExpression(Expression):
+    """A two-operand op: arithmetic / comparison / logical.
+
+    ``op`` is the operator token, e.g. ``"+"``, ``"-"``, ``"*"``, ``"/"``, ``"**"``,
+    ``"=="``, ``"!="``, ``"<"``, ``"<="``, ``">"``, ``">="``, ``"and"``, ``"or"``.
+    """
+
+    def __init__(self, op: str, left: Expression, right: Expression) -> None:
+        super().__init__([left, right])
+        self.op = op
+
+    @property
+    def left(self) -> Expression:
+        return self.children[0]
+
+    @property
+    def right(self) -> Expression:
+        return self.children[1]
+
+    def __repr__(self) -> str:
+        return f"BinaryExpression({self.op!r}, {self.left!r}, {self.right!r})"
+
+
+class UnaryExpression(Expression):
+    """A single-operand op, e.g. ``"not"``, ``"neg"``, ``"pos"``, ``"isnull"``, ``"isnotnull"``."""
+
+    def __init__(self, op: str, child: Expression) -> None:
+        super().__init__([child])
+        self.op = op
+
+    @property
+    def child(self) -> Expression:
+        return self.children[0]
+
+    def __repr__(self) -> str:
+        return f"UnaryExpression({self.op!r}, {self.child!r})"
+
+
+class Cast(Expression):
+    """A type cast. ``strict=True`` is ANSI ``cast`` (raises on bad input); ``strict=False`` is ``try_cast``.
+
+    Keeping the strict flag on the node (rather than implementing one as a delegate to the
+    other) honors the ANSI strict-vs-lenient invariant in ``CLAUDE.md``.
+    """
+
+    def __init__(self, child: Expression, target_type: Any, strict: bool) -> None:
+        super().__init__([child])
+        self.target_type = target_type
+        self.strict = strict
+
+    @property
+    def child(self) -> Expression:
+        return self.children[0]
+
+    def __repr__(self) -> str:
+        return f"Cast({self.child!r}, {self.target_type!r}, strict={self.strict})"
+
+
+class FunctionCall(Expression):
+    """A named function applied to argument expressions, e.g. ``abs(col("x"))`` -> ``FunctionCall("abs", [...])``."""
+
+    def __init__(self, name: str, args: List[Expression]) -> None:
+        super().__init__(list(args))
+        self.name = name
+
+    @property
+    def args(self) -> List[Expression]:
+        return self.children
+
+    def __repr__(self) -> str:
+        inner = ", ".join(repr(a) for a in self.args)
+        return f"FunctionCall({self.name!r}, [{inner}])"
+
+
+class CaseWhen(Expression):
+    """A ``when(...).when(...).otherwise(...)`` chain.
+
+    ``branches`` is a list of ``(condition, value)`` expression pairs; ``otherwise`` is the
+    fallback expression or ``None``.
+    """
+
+    def __init__(
+        self,
+        branches: List[Tuple[Expression, Expression]],
+        otherwise: Optional[Expression] = None,
+    ) -> None:
+        flat: List[Expression] = []
+        for cond, val in branches:
+            flat.extend([cond, val])
+        if otherwise is not None:
+            flat.append(otherwise)
+        super().__init__(flat)
+        self.branches = list(branches)
+        self.otherwise = otherwise
+
+    def __repr__(self) -> str:
+        parts = ", ".join(f"({c!r} -> {v!r})" for c, v in self.branches)
+        return f"CaseWhen([{parts}], otherwise={self.otherwise!r})"
+
+
+class Alias(Expression):
+    """A renamed expression, e.g. ``col("x").alias("y")``."""
+
+    def __init__(self, child: Expression, name: str) -> None:
+        super().__init__([child])
+        self.name = name
+
+    @property
+    def child(self) -> Expression:
+        return self.children[0]
+
+    def __repr__(self) -> str:
+        return f"Alias({self.child!r}, {self.name!r})"

--- a/sparkleframe/python/ast/expressions_test.py
+++ b/sparkleframe/python/ast/expressions_test.py
@@ -1,0 +1,90 @@
+"""Unit tests for the build-phase AST nodes.
+
+These assert structure only — the build phase records sub-expressions and makes no type
+decisions (``data_type`` stays ``None`` until the analyzer runs).
+"""
+
+from sparkleframe.python.ast.expressions import (
+    Alias,
+    AttributeReference,
+    BinaryExpression,
+    CaseWhen,
+    Cast,
+    Expression,
+    FunctionCall,
+    Literal,
+    UnaryExpression,
+)
+
+
+class TestExpressions:
+    def test_base_expression_holds_children_and_unresolved_type(self):
+        child = Literal(1)
+        expr = Expression([child])
+        assert expr.children == [child]
+        assert expr.data_type is None
+        assert "Expression" in repr(expr)
+
+    def test_literal(self):
+        lit = Literal(5)
+        assert lit.value == 5
+        assert lit.children == []
+        assert repr(lit) == "Literal(5)"
+
+    def test_literal_with_explicit_type(self):
+        lit = Literal(None, data_type="string")
+        assert lit.data_type == "string"
+
+    def test_attribute_reference(self):
+        ref = AttributeReference("a")
+        assert ref.name == "a"
+        assert repr(ref) == "AttributeReference('a')"
+
+    def test_binary_expression(self):
+        node = BinaryExpression("+", Literal(1), AttributeReference("a"))
+        assert node.op == "+"
+        assert isinstance(node.left, Literal)
+        assert isinstance(node.right, AttributeReference)
+        assert repr(node) == "BinaryExpression('+', Literal(1), AttributeReference('a'))"
+
+    def test_unary_expression(self):
+        node = UnaryExpression("not", AttributeReference("a"))
+        assert node.op == "not"
+        assert isinstance(node.child, AttributeReference)
+        assert "UnaryExpression('not'" in repr(node)
+
+    def test_cast_keeps_strict_flag(self):
+        strict = Cast(AttributeReference("a"), "int", strict=True)
+        lenient = Cast(AttributeReference("a"), "int", strict=False)
+        assert strict.strict is True
+        assert lenient.strict is False
+        assert strict.target_type == "int"
+        assert isinstance(strict.child, AttributeReference)
+        assert "strict=True" in repr(strict)
+
+    def test_function_call(self):
+        node = FunctionCall("abs", [AttributeReference("x")])
+        assert node.name == "abs"
+        assert node.args == node.children
+        assert "FunctionCall('abs'" in repr(node)
+
+    def test_case_when(self):
+        branches = [(BinaryExpression("==", AttributeReference("a"), Literal(1)), Literal("yes"))]
+        node = CaseWhen(branches, otherwise=Literal("no"))
+        assert node.branches == branches
+        assert isinstance(node.otherwise, Literal)
+        # children = condition + value + otherwise
+        assert len(node.children) == 3
+        assert "CaseWhen(" in repr(node)
+
+    def test_case_when_without_otherwise(self):
+        branches = [(AttributeReference("a"), Literal(1))]
+        node = CaseWhen(branches)
+        assert node.otherwise is None
+        assert len(node.children) == 2
+
+    def test_alias(self):
+        node = Alias(AttributeReference("a"), "b")
+        assert node.name == "b"
+        assert isinstance(node.child, AttributeReference)
+        assert repr(node) == "Alias(AttributeReference('a'), 'b')"

--- a/sparkleframe/python/column.py
+++ b/sparkleframe/python/column.py
@@ -1,114 +1,131 @@
-"""``Column`` for the pure-Python engine — a declared surface (walking skeleton).
+"""``Column`` for the pure-Python engine — the public face of the **build** phase.
 
-A :class:`Column` will be the public face of the build phase: its operators and transforms will
-construct unresolved expression-AST nodes that a later analyze → evaluate pass resolves and runs
-(see ``docs/design/python-engine-ast.md``). None of that exists yet — this class is a husk whose
-every operator and transform raises. The build phase, and the AST it produces, land with the
-engine itself.
+A :class:`Column` wraps exactly one :class:`~sparkleframe.python.ast.expressions.Expression`.
+Operators and transforms build AST nodes and make **zero type decisions** (the schema is not
+known yet). Producing an actual result happens later, when a :class:`DataFrame` action runs
+the expression through ``analyzer.analyze`` then ``evaluator.evaluate``.
+
+Methods that map cleanly onto the generic node set (arithmetic, comparison, logical, cast,
+alias, null checks) are wired. The remaining transforms are declared with their PySpark
+signatures and raise — build the matching node here when implementing them.
 """
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Union
 
 from sparkleframe.python._errors import not_implemented_yet
+from sparkleframe.python.ast.expressions import (
+    Alias,
+    AttributeReference,
+    BinaryExpression,
+    Cast,
+    Expression,
+    Literal,
+    UnaryExpression,
+)
 
 
 class Column:
-    def __init__(self) -> None:
-        """No state yet; the wrapped expression arrives with the build phase."""
+    def __init__(self, expr: Expression) -> None:
+        if not isinstance(expr, Expression):
+            raise TypeError(f"Column expects an Expression, got {type(expr).__name__}")
+        self._expr = expr
 
     # --- Arithmetic ---------------------------------------------------------
     def __add__(self, other: Any) -> "Column":
-        not_implemented_yet("Column.__add__")
+        return Column(BinaryExpression("+", self._expr, _to_expression(other)))
 
     def __sub__(self, other: Any) -> "Column":
-        not_implemented_yet("Column.__sub__")
+        return Column(BinaryExpression("-", self._expr, _to_expression(other)))
 
     def __mul__(self, other: Any) -> "Column":
-        not_implemented_yet("Column.__mul__")
+        return Column(BinaryExpression("*", self._expr, _to_expression(other)))
 
     def __truediv__(self, other: Any) -> "Column":
-        not_implemented_yet("Column.__truediv__")
+        return Column(BinaryExpression("/", self._expr, _to_expression(other)))
 
     def __pow__(self, other: Any) -> "Column":
-        not_implemented_yet("Column.__pow__")
+        return Column(BinaryExpression("**", self._expr, _to_expression(other)))
 
     def __radd__(self, other: Any) -> "Column":
-        not_implemented_yet("Column.__radd__")
+        return Column(BinaryExpression("+", _to_expression(other), self._expr))
 
     def __rsub__(self, other: Any) -> "Column":
-        not_implemented_yet("Column.__rsub__")
+        return Column(BinaryExpression("-", _to_expression(other), self._expr))
 
     def __rmul__(self, other: Any) -> "Column":
-        not_implemented_yet("Column.__rmul__")
+        return Column(BinaryExpression("*", _to_expression(other), self._expr))
 
     def __rtruediv__(self, other: Any) -> "Column":
-        not_implemented_yet("Column.__rtruediv__")
+        return Column(BinaryExpression("/", _to_expression(other), self._expr))
 
     def __rpow__(self, other: Any) -> "Column":
-        not_implemented_yet("Column.__rpow__")
+        return Column(BinaryExpression("**", _to_expression(other), self._expr))
 
     def __neg__(self) -> "Column":
-        not_implemented_yet("Column.__neg__")
+        return Column(UnaryExpression("neg", self._expr))
 
     def __pos__(self) -> "Column":
-        not_implemented_yet("Column.__pos__")
+        return Column(UnaryExpression("pos", self._expr))
 
     # --- Comparison ---------------------------------------------------------
     def __eq__(self, other: Any) -> "Column":  # type: ignore[override]
-        not_implemented_yet("Column.__eq__")
+        return Column(BinaryExpression("==", self._expr, _to_expression(other)))
 
     def __ne__(self, other: Any) -> "Column":  # type: ignore[override]
-        not_implemented_yet("Column.__ne__")
+        return Column(BinaryExpression("!=", self._expr, _to_expression(other)))
 
     def __lt__(self, other: Any) -> "Column":
-        not_implemented_yet("Column.__lt__")
+        return Column(BinaryExpression("<", self._expr, _to_expression(other)))
 
     def __le__(self, other: Any) -> "Column":
-        not_implemented_yet("Column.__le__")
+        return Column(BinaryExpression("<=", self._expr, _to_expression(other)))
 
     def __gt__(self, other: Any) -> "Column":
-        not_implemented_yet("Column.__gt__")
+        return Column(BinaryExpression(">", self._expr, _to_expression(other)))
 
     def __ge__(self, other: Any) -> "Column":
-        not_implemented_yet("Column.__ge__")
+        return Column(BinaryExpression(">=", self._expr, _to_expression(other)))
 
     # Column overrides __eq__, so it is unhashable by default — mirror PySpark.
     __hash__ = None  # type: ignore[assignment]
 
     # --- Logical ------------------------------------------------------------
     def __and__(self, other: Any) -> "Column":
-        not_implemented_yet("Column.__and__")
+        return Column(BinaryExpression("and", self._expr, _to_expression(other)))
 
     def __rand__(self, other: Any) -> "Column":
-        not_implemented_yet("Column.__rand__")
+        return Column(BinaryExpression("and", _to_expression(other), self._expr))
 
     def __or__(self, other: Any) -> "Column":
-        not_implemented_yet("Column.__or__")
+        return Column(BinaryExpression("or", self._expr, _to_expression(other)))
 
     def __ror__(self, other: Any) -> "Column":
-        not_implemented_yet("Column.__ror__")
+        return Column(BinaryExpression("or", _to_expression(other), self._expr))
 
     def __invert__(self) -> "Column":
-        not_implemented_yet("Column.__invert__")
+        return Column(UnaryExpression("not", self._expr))
 
-    # --- Transforms ---------------------------------------------------------
+    # --- Transforms (build wired) ------------------------------------------
     def alias(self, name: str) -> "Column":
-        not_implemented_yet("Column.alias")
+        return Column(Alias(self._expr, name))
 
     def cast(self, data_type: Any) -> "Column":
-        not_implemented_yet("Column.cast")
+        """ANSI-strict cast: raises on malformed input at evaluate time (Spark 4 default)."""
+        return Column(Cast(self._expr, data_type, strict=True))
 
-    def try_cast(self, data_type: Any) -> "Column":
-        not_implemented_yet("Column.try_cast")
+    def try_cast(self, data_type: Union[Any, str]) -> "Column":
+        """Lenient cast (Spark 4 ``try_cast``): returns null instead of raising."""
+        return Column(Cast(self._expr, data_type, strict=False))
 
     def isNull(self) -> "Column":
-        not_implemented_yet("Column.isNull")
+        return Column(UnaryExpression("isnull", self._expr))
 
     def isNotNull(self) -> "Column":
-        not_implemented_yet("Column.isNotNull")
+        return Column(UnaryExpression("isnotnull", self._expr))
 
+    # --- Transforms (slots — build the matching node when implementing) -----
     def isin(self, *values: Any) -> "Column":
         not_implemented_yet("Column.isin")
 
@@ -118,10 +135,10 @@ class Column:
     def contains(self, substring: str) -> "Column":
         not_implemented_yet("Column.contains")
 
-    def getItem(self, key: Any) -> "Column":
+    def getItem(self, key: Union[str, int]) -> "Column":
         not_implemented_yet("Column.getItem")
 
-    def __getitem__(self, key: Any) -> "Column":
+    def __getitem__(self, key: Union[str, int]) -> "Column":
         not_implemented_yet("Column.__getitem__")
 
     def asc(self) -> "Column":
@@ -137,4 +154,29 @@ class Column:
         not_implemented_yet("Column.desc_nulls_last")
 
     def __repr__(self) -> str:
-        return "Column()"
+        return f"Column({self._expr!r})"
+
+
+def _to_expression(value: Any) -> Expression:
+    """Coerce an operand into an :class:`Expression` for the build phase.
+
+    A :class:`Column` contributes its wrapped expression; a raw :class:`Expression` is used
+    as-is; anything else is a constant literal. (Column *names* become references only via
+    :func:`sparkleframe.python.functions.col`, never here.)
+    """
+    if isinstance(value, Column):
+        return value._expr
+    if isinstance(value, Expression):
+        return value
+    return Literal(value)
+
+
+def _column_ref(value: Any) -> Expression:
+    """Coerce a ``str | Column`` 'column argument' into an :class:`Expression`.
+
+    Unlike :func:`_to_expression`, a bare ``str`` here means a *column name* (the convention
+    for ``functions`` like ``abs(col_name)``), so it becomes an :class:`AttributeReference`.
+    """
+    if isinstance(value, str):
+        return AttributeReference(value)
+    return _to_expression(value)

--- a/sparkleframe/python/column_test.py
+++ b/sparkleframe/python/column_test.py
@@ -1,55 +1,141 @@
-"""Unit tests for ``Column`` — a declared husk whose every operator and transform raises."""
+"""Unit tests for ``Column`` — the build-phase operators and the unimplemented slots.
+
+These tests pin the *AST shape* produced by Column dunder methods. They must lock both the
+operator and operand placement for non-commutative reflected ops (``__rsub__``,
+``__rtruediv__``, ``__rpow__``) — otherwise a build bug that swaps left/right slips through.
+"""
 
 import pytest
 
-import sparkleframe.python.column_helpers as column_helpers
-from sparkleframe.python.column import Column
+from sparkleframe.python.ast.expressions import (
+    Alias,
+    AttributeReference,
+    BinaryExpression,
+    Cast,
+    Literal,
+    UnaryExpression,
+)
+from sparkleframe.python.column import Column, _column_ref, _to_expression
+
+
+def _col(name: str = "a") -> Column:
+    return Column(AttributeReference(name))
 
 
 class TestColumnConstruction:
-    def test_constructs(self):
-        assert isinstance(Column(), Column)
-
-    def test_repr(self):
-        assert "Column" in repr(Column())
-
-    def test_is_unhashable_like_pyspark(self):
+    def test_rejects_non_expression(self):
         with pytest.raises(TypeError):
-            hash(Column())
+            Column("a")  # must wrap an Expression, not a raw name
+
+    def test_repr_includes_inner_expression(self):
+        # repr must delegate to the wrapped expression so debugging output is useful.
+        assert "a" in repr(_col("a"))
 
 
-class TestColumnOpsRaise:
+class TestColumnBuildPhase:
+    @pytest.mark.parametrize(
+        "build, op",
+        [
+            (lambda c: c + 1, "+"),
+            (lambda c: c - 1, "-"),
+            (lambda c: c * 2, "*"),
+            (lambda c: c / 2, "/"),
+            (lambda c: c**2, "**"),
+            (lambda c: 1 + c, "+"),
+            (lambda c: 1 - c, "-"),
+            (lambda c: 2 * c, "*"),
+            (lambda c: 2 / c, "/"),
+            (lambda c: 2**c, "**"),
+            (lambda c: c == 1, "=="),
+            (lambda c: c != 1, "!="),
+            (lambda c: c < 1, "<"),
+            (lambda c: c <= 1, "<="),
+            (lambda c: c > 1, ">"),
+            (lambda c: c >= 1, ">="),
+            (lambda c: c & _col("b"), "and"),
+            (lambda c: c | _col("b"), "or"),
+            (lambda c: _col("b") & c, "and"),
+            (lambda c: _col("b") | c, "or"),
+        ],
+    )
+    def test_binary_ops_build_binary_expression(self, build, op):
+        result = build(_col())
+        assert isinstance(result, Column)
+        assert isinstance(result._expr, BinaryExpression)
+        assert result._expr.op == op
+
+    @pytest.mark.parametrize(
+        "build, op",
+        [
+            (lambda c: 1 - c, "-"),
+            (lambda c: 2 / c, "/"),
+            (lambda c: 2**c, "**"),
+        ],
+    )
+    def test_reflected_non_commutative_ops_keep_literal_on_left(self, build, op):
+        """Reflected dunders (``__rsub__`` etc.) must place the literal on the left.
+
+        Asserting ``op == "-"`` alone passes even if ``__rsub__`` swaps operands. Lock
+        operand placement so a swap regression actually fails.
+        """
+        result = build(_col("a"))
+        assert result._expr.op == op
+        assert isinstance(result._expr.left, Literal)
+        assert isinstance(result._expr.right, AttributeReference)
+        assert result._expr.right.name == "a"
+
+    @pytest.mark.parametrize(
+        "build, op",
+        [
+            (lambda c: _col("b") & c, "and"),
+            (lambda c: _col("b") | c, "or"),
+        ],
+    )
+    def test_reflected_boolean_ops_keep_other_column_on_left(self, build, op):
+        result = build(_col("a"))
+        assert result._expr.op == op
+        assert isinstance(result._expr.left, AttributeReference) and result._expr.left.name == "b"
+        assert isinstance(result._expr.right, AttributeReference) and result._expr.right.name == "a"
+
+    @pytest.mark.parametrize(
+        "build, op",
+        [
+            (lambda c: -c, "neg"),
+            (lambda c: +c, "pos"),
+            (lambda c: ~c, "not"),
+            (lambda c: c.isNull(), "isnull"),
+            (lambda c: c.isNotNull(), "isnotnull"),
+        ],
+    )
+    def test_unary_ops_build_unary_expression(self, build, op):
+        result = build(_col())
+        assert isinstance(result._expr, UnaryExpression)
+        assert result._expr.op == op
+
+    def test_alias(self):
+        result = _col().alias("b")
+        assert isinstance(result._expr, Alias)
+        assert result._expr.name == "b"
+
+    def test_cast_is_strict(self):
+        result = _col().cast("int")
+        assert isinstance(result._expr, Cast)
+        assert result._expr.strict is True
+
+    def test_try_cast_is_lenient(self):
+        result = _col().try_cast("int")
+        assert isinstance(result._expr, Cast)
+        assert result._expr.strict is False
+
+    def test_column_is_unhashable_like_pyspark(self):
+        with pytest.raises(TypeError):
+            hash(_col())
+
+
+class TestColumnSlotsRaise:
     @pytest.mark.parametrize(
         "call",
         [
-            lambda c: c + 1,
-            lambda c: c - 1,
-            lambda c: c * 2,
-            lambda c: c / 2,
-            lambda c: c**2,
-            lambda c: 1 + c,
-            lambda c: 1 - c,
-            lambda c: 2 * c,
-            lambda c: 2 / c,
-            lambda c: 2**c,
-            lambda c: -c,
-            lambda c: +c,
-            lambda c: ~c,
-            lambda c: c == 1,
-            lambda c: c != 1,
-            lambda c: c < 1,
-            lambda c: c <= 1,
-            lambda c: c > 1,
-            lambda c: c >= 1,
-            lambda c: c & Column(),
-            lambda c: c | Column(),
-            lambda c: Column() & c,
-            lambda c: Column() | c,
-            lambda c: c.alias("b"),
-            lambda c: c.cast("int"),
-            lambda c: c.try_cast("int"),
-            lambda c: c.isNull(),
-            lambda c: c.isNotNull(),
             lambda c: c.isin(1, 2),
             lambda c: c.rlike("x"),
             lambda c: c.contains("x"),
@@ -61,11 +147,21 @@ class TestColumnOpsRaise:
             lambda c: c.desc_nulls_last(),
         ],
     )
-    def test_op_raises(self, call):
+    def test_unimplemented_transforms_raise(self, call):
         with pytest.raises(NotImplementedError):
-            call(Column())
+            call(_col())
 
 
-def test_column_helpers_module_importable():
-    # Placeholder module for shared column logic; assert it loads.
-    assert isinstance(column_helpers.__name__, str)
+class TestExpressionCoercion:
+    def test_to_expression_passthrough_and_literal(self):
+        col = _col()
+        assert _to_expression(col) is col._expr
+        node = Literal(1)
+        assert _to_expression(node) is node
+        assert isinstance(_to_expression(7), Literal)
+
+    def test_column_ref_treats_str_as_attribute(self):
+        assert isinstance(_column_ref("a"), AttributeReference)
+        col = _col()
+        assert _column_ref(col) is col._expr
+        assert isinstance(_column_ref(7), Literal)

--- a/sparkleframe/python/dataframe.py
+++ b/sparkleframe/python/dataframe.py
@@ -1,9 +1,9 @@
-"""``DataFrame`` for the pure-Python engine — a walking skeleton.
+"""``DataFrame`` for the pure-Python engine.
 
 The constructor stores the rows and the (PySpark) schema verbatim — that is the data the
-build → analyze → evaluate flow will consume. Every transformation and action is a raising slot
-for now; they land incrementally as the analyze (type resolution) and evaluate (execution) phases
-are implemented (see ``docs/design/python-engine-ast.md``).
+build → analyze → evaluate flow consumes. A transformation resolves its column expressions through
+``analyzer.analyze`` (type resolution, against the schema) then ``evaluator.evaluate`` (execution),
+producing a new frame. Operations beyond ``select`` are not implemented yet and raise.
 
 Type handling: per the engine's first-pass decision the schema is a PySpark ``StructType``
 consumed directly (see ``docs/design/python-engine-ast.md`` and the plan).
@@ -15,7 +15,16 @@ from typing import Any, List, Optional, Tuple, Union
 
 from sparkleframe.base.dataframe import DataFrame as BaseDataFrame
 from sparkleframe.python._errors import not_implemented_yet
+from sparkleframe.python.ast.analyzer import analyze
+from sparkleframe.python.ast.evaluator import evaluate
 from sparkleframe.python.column import Column
+from sparkleframe.python.dataframe_helpers import output_name, rows_as_dicts
+from sparkleframe.python.functions import col as _col
+
+try:  # pragma: no cover - exercised only with the real pyspark installed
+    from pyspark.sql.types import StructField, StructType
+except Exception:  # pragma: no cover - mock pyspark (under activate) has no real types
+    pass
 
 
 class DataFrame(BaseDataFrame):
@@ -26,7 +35,8 @@ class DataFrame(BaseDataFrame):
         self._schema = schema
 
     def to_records(self) -> list:
-        not_implemented_yet("DataFrame.to_records")
+        """Engine → ``list[dict]`` for the parity oracle: zip schema names with each row tuple."""
+        return rows_as_dicts(self._rows, self._schema)
 
     def columns(self) -> List[str]:
         not_implemented_yet("DataFrame.columns")
@@ -44,7 +54,20 @@ class DataFrame(BaseDataFrame):
         not_implemented_yet("DataFrame.alias")
 
     def select(self, *cols: Union[str, Column, List[str], List[Column]]) -> "DataFrame":
-        not_implemented_yet("DataFrame.select")
+        columns = [c if isinstance(c, Column) else _col(c) if isinstance(c, str) else None for c in cols]
+        if any(c is None for c in columns):
+            not_implemented_yet("DataFrame.select for non-str/Column arguments")
+
+        input_rows = rows_as_dicts(self._rows, self._schema)
+        out_fields = []
+        out_values = []  # one value list per output column
+        for column in columns:
+            resolved = analyze(column._expr, self._schema)
+            out_fields.append(StructField(output_name(resolved), resolved.data_type))
+            out_values.append(evaluate(resolved, input_rows))
+
+        out_rows = [tuple(values[i] for values in out_values) for i in range(len(self._rows))]
+        return DataFrame(out_rows, StructType(out_fields))
 
     def filter(self, condition: Union[str, Column]) -> "DataFrame":
         not_implemented_yet("DataFrame.filter")

--- a/sparkleframe/python/dataframe_helpers.py
+++ b/sparkleframe/python/dataframe_helpers.py
@@ -1,6 +1,38 @@
 """Shared, private helpers for ``dataframe.py`` (pure-Python engine).
 
 Per the repo convention (CLAUDE.md), shared/private logic for the public ``dataframe`` surface
-lives here rather than in ``dataframe.py``. Empty for now — helpers land alongside the DataFrame
-operations they support as the analyze/evaluate phases are implemented.
+lives here rather than in ``dataframe.py``. These helpers bridge the stored row tuples + PySpark
+schema into the dict form the analyze/evaluate phases consume, and reassemble the output frame.
 """
+
+from __future__ import annotations
+
+from typing import Any, List
+
+from sparkleframe.python.ast.expressions import Alias, AttributeReference, BinaryExpression, Expression
+
+
+def field_names(schema: Any) -> List[str]:
+    """Column names of a PySpark ``StructType`` schema."""
+    return [field.name for field in schema.fields]
+
+
+def rows_as_dicts(rows: List[tuple], schema: Any) -> List[dict]:
+    """Pair each stored row tuple with the schema's column names → list of dicts."""
+    names = field_names(schema)
+    return [dict(zip(names, row)) for row in rows]
+
+
+def output_name(resolved: Expression) -> str:
+    """Derive the output column name of a resolved expression, Spark-style.
+
+    ``Alias`` and ``AttributeReference`` carry an explicit name; other nodes fall back to a
+    generated label (Spark would generate one too, e.g. ``(a + b)``).
+    """
+    if isinstance(resolved, Alias):
+        return resolved.name
+    if isinstance(resolved, AttributeReference):
+        return resolved.name
+    if isinstance(resolved, BinaryExpression):
+        return f"({output_name(resolved.left)} {resolved.op} {output_name(resolved.right)})"
+    return repr(resolved)

--- a/sparkleframe/python/dataframe_test.py
+++ b/sparkleframe/python/dataframe_test.py
@@ -1,8 +1,18 @@
-"""Unit tests for ``DataFrame``: the constructor stores state; every action is a slot that raises."""
+"""Unit tests for ``DataFrame``: the constructor stores state; every action is a slot that raises.
+
+Scope rules for this file:
+- Tests the orchestration contract that only ``select`` owns: projection, output order,
+  output names, resolved output dtypes, argument handling, and unimplemented slots.
+- Does NOT re-assert arithmetic or coercion *values* — those are owned by ``evaluator_test``,
+  ``coercion_test``, and the engine-vs-Spark ``arithmetic_parity_test`` (which is strictly
+  stronger than a colocated value assertion).
+- Fixtures use ≥2 columns whenever a property could otherwise pass vacuously.
+"""
 
 import pytest
+from pyspark.sql.types import IntegerType, LongType, StructField, StructType
 
-import sparkleframe.python.dataframe_helpers as dataframe_helpers
+import sparkleframe.python.functions as F
 from sparkleframe.python.dataframe import DataFrame
 
 
@@ -23,13 +33,11 @@ class TestDataFrameActionsRaise:
     @pytest.mark.parametrize(
         "call",
         [
-            lambda df: df.to_records(),
             lambda df: df.columns(),
             lambda df: df.schema(),
             lambda df: df.dtypes(),
             lambda df: df["a"],
             lambda df: df.alias("x"),
-            lambda df: df.select("a"),
             lambda df: df.filter("a > 1"),
             lambda df: df.where("a > 1"),
             lambda df: df.withColumn("b", None),
@@ -58,5 +66,66 @@ class TestDataFrameActionsRaise:
             call(df)
 
 
-def test_dataframe_helpers_module_importable():
-    assert isinstance(dataframe_helpers.__name__, str)
+class TestToRecords:
+    def test_to_records_zips_schema_field_names_to_row_tuples(self):
+        schema = StructType([StructField("a", IntegerType()), StructField("b", IntegerType())])
+        df = DataFrame([(1, 10), (2, 20)], schema)
+        assert df.to_records() == [{"a": 1, "b": 10}, {"a": 2, "b": 20}]
+
+
+class TestSelectOrchestration:
+    """``select`` owns: projection, output order, output names, output dtypes, arg handling.
+
+    Value-level correctness is owned by ``arithmetic_parity_test`` (vs real Spark) and the
+    AST-phase unit tests. These tests must not re-assert arithmetic or coercion values.
+    """
+
+    @staticmethod
+    def _three_col_int_df() -> DataFrame:
+        schema = StructType(
+            [
+                StructField("a", IntegerType()),
+                StructField("b", IntegerType()),
+                StructField("c", IntegerType()),
+            ]
+        )
+        return DataFrame([(1, 10, 100), (2, 20, 200)], schema)
+
+    def test_select_subset_drops_unreferenced_columns(self):
+        out = self._three_col_int_df().select("a", "c")
+        assert [f.name for f in out._schema.fields] == ["a", "c"]
+        assert out.to_records() == [{"a": 1, "c": 100}, {"a": 2, "c": 200}]
+
+    def test_select_output_order_follows_select_args_not_schema_order(self):
+        out = self._three_col_int_df().select("c", "a")
+        assert [f.name for f in out._schema.fields] == ["c", "a"]
+
+    def test_select_single_string_arg_projects_named_column(self):
+        out = self._three_col_int_df().select("b")
+        assert [f.name for f in out._schema.fields] == ["b"]
+        assert out.to_records() == [{"b": 10}, {"b": 20}]
+
+    def test_select_alias_overrides_field_name_in_output_schema(self):
+        out = self._three_col_int_df().select(F.col("a").alias("x"), "b")
+        assert [f.name for f in out._schema.fields] == ["x", "b"]
+
+    def test_select_mixes_expression_and_bare_column(self):
+        out = self._three_col_int_df().select((F.col("a") + F.col("b")).alias("sum"), "c")
+        assert [f.name for f in out._schema.fields] == ["sum", "c"]
+
+    def test_select_resolves_output_dtype_from_analyze(self):
+        """Int + Long → Long: proves ``select`` actually ran the analyze phase.
+
+        The *value* of the sum is owned by parity / evaluator tests. We only assert dtype
+        resolution here, and we pick a coercion case (Int+Long) distinct from coercion_test's
+        primary table so this isn't a duplicate of that file either.
+        """
+        schema = StructType([StructField("i", IntegerType()), StructField("l", LongType())])
+        df = DataFrame([(1, 2)], schema)
+        out = df.select((F.col("i") + F.col("l")).alias("r"))
+        assert isinstance(out._schema["r"].dataType, LongType)
+
+    def test_select_unsupported_arg_raises(self):
+        df = self._three_col_int_df()
+        with pytest.raises(NotImplementedError):
+            df.select(["a"])

--- a/sparkleframe/python/functions.py
+++ b/sparkleframe/python/functions.py
@@ -1,10 +1,12 @@
-"""``pyspark.sql.functions`` surface for the pure-Python engine — a declared surface (walking skeleton).
+"""``pyspark.sql.functions`` surface for the pure-Python engine.
 
-Each function will be part of the build phase: it will construct an unresolved expression-AST node
-that a later analyze → evaluate pass resolves and runs (see ``docs/design/python-engine-ast.md``).
-None of that exists yet — every function here is a declared slot that raises, documenting the
-surface so it can be filled in (and the matching id drained from the Python parity gate in
-``sparkleframe/tests/parity/gaps.py``) as the engine lands.
+Each function is part of the **build** phase: it constructs an unresolved AST node (see
+:mod:`sparkleframe.python.ast.expressions`) and makes no type decisions. A handful of
+representative functions are wired to show the pattern across every node kind
+(:class:`AttributeReference`, :class:`Literal`, :class:`FunctionCall`, :class:`CaseWhen`);
+the remainder are declared with their PySpark signatures and raise — build the matching node
+here, then teach the analyzer/evaluator to handle it (and drain the gate in
+``sparkleframe/tests/parity/gaps.py``).
 """
 
 from __future__ import annotations
@@ -12,39 +14,61 @@ from __future__ import annotations
 from typing import Any, Callable, Optional, Union
 
 from sparkleframe.python._errors import not_implemented_yet
-from sparkleframe.python.column import Column
+from sparkleframe.python.ast.expressions import AttributeReference, CaseWhen, Expression, FunctionCall, Literal
+from sparkleframe.python.column import Column, _column_ref, _to_expression
 
 
-# --- Column builders --------------------------------------------------------
+def _fn(name: str, *cols: Any) -> Column:
+    """Build a :class:`Column` wrapping ``FunctionCall(name, [...])`` over column arguments."""
+    return Column(FunctionCall(name, [_column_ref(c) for c in cols]))
+
+
+# --- Column builders (build wired) -----------------------------------------
 def col(name: str) -> Column:
-    not_implemented_yet("functions.col")
+    return Column(AttributeReference(name))
 
 
 def lit(value: Any) -> Column:
-    not_implemented_yet("functions.lit")
+    return Column(Literal(value))
 
 
-def when(condition: Any, value: Any) -> Column:
-    not_implemented_yet("functions.when")
+class WhenBuilder:
+    """Accumulates ``when(...).when(...)`` branches; ``otherwise`` finalizes into a :class:`CaseWhen`."""
+
+    def __init__(self, condition: Any, value: Any) -> None:
+        self._branches: list[tuple[Expression, Expression]] = [(_to_expression(condition), _to_expression(value))]
+
+    def when(self, condition: Any, value: Any) -> "WhenBuilder":
+        self._branches.append((_to_expression(condition), _to_expression(value)))
+        return self
+
+    def otherwise(self, value: Any) -> Column:
+        return Column(CaseWhen(self._branches, _to_expression(value)))
 
 
-# --- Remaining surface (slots) ----------------------------------------------
+def when(condition: Any, value: Any) -> WhenBuilder:
+    """Start a multi-branch conditional; chain ``.when(...).otherwise(...)``."""
+    return WhenBuilder(condition, value)
+
+
+# --- A few representative wrappers (build wired) ---------------------------
 def abs(col_name: Union[str, Column]) -> Column:
-    not_implemented_yet("functions.abs")
+    return _fn("abs", col_name)
 
 
 def lower(col_name: Union[str, Column]) -> Column:
-    not_implemented_yet("functions.lower")
+    return _fn("lower", col_name)
 
 
 def count(col_name: Union[str, Column]) -> Column:
-    not_implemented_yet("functions.count")
+    return _fn("count", col_name)
 
 
 def coalesce(*cols: Union[str, Column]) -> Column:
-    not_implemented_yet("functions.coalesce")
+    return _fn("coalesce", *cols)
 
 
+# --- Remaining surface (slots — build the node when implementing) ----------
 def get_json_object(col: Union[str, Column], path: str) -> Column:
     not_implemented_yet("functions.get_json_object")
 

--- a/sparkleframe/python/functions_test.py
+++ b/sparkleframe/python/functions_test.py
@@ -1,20 +1,63 @@
-"""Unit tests for the ``functions`` surface — every function is a slot that raises until the engine lands."""
+"""Unit tests for the ``functions`` surface: build-wired functions and unimplemented slots.
+
+As functions are implemented they must move from ``_UNIMPLEMENTED`` (slot-raises) into a
+positive build-shape test that asserts the AST node produced. Removing from one list without
+adding the other leaves the surface untested.
+"""
 
 import pytest
 
 import sparkleframe.python.functions as F
-import sparkleframe.python.functions_helpers as functions_helpers
+from sparkleframe.python.ast.expressions import AttributeReference, CaseWhen, FunctionCall, Literal
+from sparkleframe.python.column import Column
 
-# Every function is a declared slot that raises until implemented. Calling each one (with dummy
-# arguments) both documents the surface and guards that the slot stays wired.
+
+class TestBuildWiredFunctions:
+    def test_col_builds_attribute_reference(self):
+        result = F.col("a")
+        assert isinstance(result, Column)
+        assert isinstance(result._expr, AttributeReference)
+        assert result._expr.name == "a"
+
+    @pytest.mark.parametrize("value", [5, "x", True, 1.5, None])
+    def test_lit_builds_literal_for_each_supported_type(self, value):
+        result = F.lit(value)
+        assert isinstance(result._expr, Literal)
+        assert result._expr.value == value
+
+    @pytest.mark.parametrize("fn, name", [(F.abs, "abs"), (F.lower, "lower"), (F.count, "count")])
+    def test_single_arg_functions_build_function_call(self, fn, name):
+        result = fn("x")
+        assert isinstance(result._expr, FunctionCall)
+        assert result._expr.name == name
+        assert isinstance(result._expr.args[0], AttributeReference)
+
+    def test_coalesce_is_variadic(self):
+        result = F.coalesce("a", "b", F.lit(0))
+        assert isinstance(result._expr, FunctionCall)
+        assert result._expr.name == "coalesce"
+        assert len(result._expr.args) == 3
+
+    def test_when_otherwise_builds_case_when_preserving_branch_order(self):
+        result = F.when(F.col("a") == 1, F.lit("yes")).when(F.col("a") == 2, F.lit("maybe")).otherwise(F.lit("no"))
+        assert isinstance(result, Column)
+        assert isinstance(result._expr, CaseWhen)
+        assert len(result._expr.branches) == 2
+
+        # Lock branch order: first .when before second .when.
+        first_value = result._expr.branches[0][1]
+        second_value = result._expr.branches[1][1]
+        assert isinstance(first_value, Literal) and first_value.value == "yes"
+        assert isinstance(second_value, Literal) and second_value.value == "maybe"
+
+        # otherwise is the trailing literal, not folded into a branch.
+        assert isinstance(result._expr.otherwise, Literal)
+        assert result._expr.otherwise.value == "no"
+
+
+# Every remaining function is a declared slot that raises until implemented. Calling each one
+# (with dummy arguments) both documents the surface and guards that the slot stays wired.
 _UNIMPLEMENTED = [
-    lambda: F.col("a"),
-    lambda: F.lit(5),
-    lambda: F.when(object(), object()),
-    lambda: F.abs("a"),
-    lambda: F.lower("a"),
-    lambda: F.count("a"),
-    lambda: F.coalesce("a", "b"),
     lambda: F.get_json_object("c", "$.a"),
     lambda: F.from_json("c", "int"),
     lambda: F.to_json("c"),
@@ -82,10 +125,6 @@ _UNIMPLEMENTED = [
 
 
 @pytest.mark.parametrize("call", _UNIMPLEMENTED)
-def test_functions_raise(call):
+def test_unimplemented_functions_raise(call):
     with pytest.raises(NotImplementedError):
         call()
-
-
-def test_functions_helpers_module_importable():
-    assert isinstance(functions_helpers.__name__, str)

--- a/sparkleframe/python/session_test.py
+++ b/sparkleframe/python/session_test.py
@@ -1,5 +1,7 @@
 """Unit tests for ``SparkSession`` — the builder and ``createDataFrame`` entry point are wired."""
 
+from pyspark.sql.types import IntegerType, StructField, StructType
+
 from sparkleframe.python.dataframe import DataFrame
 from sparkleframe.python.session import SparkSession
 
@@ -9,11 +11,17 @@ class TestSparkSession:
         session = SparkSession.builder.appName("app").master("local").config("k", "v").getOrCreate()
         assert isinstance(session, SparkSession)
 
-    def test_create_dataframe_returns_dataframe(self):
+    def test_create_dataframe_passes_rows_and_schema_through(self):
+        schema = StructType([StructField("a", IntegerType()), StructField("b", IntegerType())])
         session = SparkSession()
-        df = session.createDataFrame([(1, 2)], schema=None)
-        assert isinstance(df, DataFrame)
-        assert df._rows == [(1, 2)]
+        df = session.createDataFrame([(1, 2), (3, 4)], schema=schema)
 
-    def test_spark_context_set_log_level_is_noop(self):
+        assert isinstance(df, DataFrame)
+        assert df._rows == [(1, 2), (3, 4)]
+        # Schema must be passed through (same instance), not copied or normalized away.
+        assert df._schema is schema
+
+    def test_spark_context_set_log_level_is_documented_noop(self):
+        # Spark API surface compatibility: ``setLogLevel`` exists and returns ``None`` so
+        # caller code written against PySpark continues to type-check and run.
         assert SparkSession.sparkContext.setLogLevel("INFO") is None

--- a/sparkleframe/tests/parity/arithmetic_parity_test.py
+++ b/sparkleframe/tests/parity/arithmetic_parity_test.py
@@ -6,12 +6,12 @@ result is defined by Spark — not by any engine.
 
 The gating in ``gaps.py`` is what makes this safe while engines are incomplete:
 
-- ``same_type`` (int + int) is supported by Polars (runs green) and gated for
-  Python (xfail until the engine lands).
-- ``numeric_plus_string`` and ``int_plus_date`` are gated for **both** Polars
-  (documented gaps) and Python (not built). When Python's analyzer lands and the
-  id is deleted from ``PYTHON_NOT_IMPLEMENTED``, this test becomes required-to-pass
-  for Python — proving Python fixed a gap Polars still has.
+- ``same_type`` (int + int) is supported by both Polars and Python (runs green).
+- ``numeric_plus_string`` is a documented Polars gap (still ``xfail`` for Polars)
+  but is **implemented for Python**: its analyze phase resolves the operand types
+  against the schema and casts the string to double, so the test is now
+  required-to-pass for Python — proving Python fixed a gap Polars still has.
+- ``int_plus_date`` is still gated for **both** engines (not built yet).
 """
 
 import pyspark.sql.functions as SF
@@ -43,5 +43,20 @@ def test_double_plus_string(engine, spark):
 
     actual = engine.build_df(rows, schema).select((F.col("d") + F.col("s")).alias("r"))
     expected = spark.createDataFrame(rows, schema).select((SF.col("d") + SF.col("s")).alias("r"))
+
+    assert_matches_spark(actual, expected, engine)
+
+
+@pytest.mark.feature("arithmetic.numeric_plus_string")
+def test_int_plus_string(engine, spark):
+    # With an int operand, Spark casts the string to BIGINT (e.g. 1 + "3" -> 4),
+    # unlike the double case which casts to double. Decimal strings like "0.5"
+    # would be a malformed BIGINT cast and raise under ANSI.
+    rows = [(1, "3"), (2, "40")]
+    schema = StructType([StructField("a", IntegerType()), StructField("s", StringType())])
+    F = engine.functions
+
+    actual = engine.build_df(rows, schema).select((F.col("a") + F.col("s")).alias("r"))
+    expected = spark.createDataFrame(rows, schema).select((SF.col("a") + SF.col("s")).alias("r"))
 
     assert_matches_spark(actual, expected, engine)

--- a/sparkleframe/tests/parity/gaps.py
+++ b/sparkleframe/tests/parity/gaps.py
@@ -21,12 +21,10 @@ POLARS_NOT_SUPPORTED = {
     "arithmetic.int_plus_date",
 }
 
-# Python engine — nothing is implemented yet, so every behavior under test is
-# gated. Seed this from the parity tests as they are written; drain it as the
-# build → analyze → evaluate engine lands (#102).
+# Python engine — gated behaviors awaiting the build → analyze → evaluate engine
+# (#102). Drain an id as each behavior lands; entries the Python set holds but the
+# Polars set does not are polars gaps the Python engine is expected to fix.
 PYTHON_NOT_IMPLEMENTED = {
-    "arithmetic.same_type",
-    "arithmetic.numeric_plus_string",
     "arithmetic.int_plus_date",
     # column_parity_test.py — Column arithmetic / comparison / cast (lifted from column_test.py).
     "column.arithmetic.col_col",
@@ -206,4 +204,4 @@ GATES = {
 # lower it (never raise it) when you delete entries. The ratchet test enforces
 # that the live set never exceeds this number, so a regression can't quietly
 # re-gate a behavior instead of being fixed.
-PYTHON_GATE_HIGH_WATER_MARK = 167
+PYTHON_GATE_HIGH_WATER_MARK = 165


### PR DESCRIPTION
## What

Builds out the `sparkleframe/python` engine on top of the scaffold in #108: the unresolved expression **AST** (build), schema-driven **type resolution** with coercion `Cast` insertion (analyze), and **execution** (evaluate) — flowing end-to-end for the first vertical slice.

> **Stacked on #108.** This PR is based on `scaffold-python-engine`; review #108 first. Once #108 merges to `main`, this retargets to `main` and its diff stays AST-only.

## The slice

Numeric arithmetic (`+ - *`) with numeric widening and the `numeric + string` coercion, resolved once the schema is known. `double + "3.14" → double` works on the Python engine — a gap Polars still has.

## Contents (diff vs #108)

- **`ast/`**: `expressions.py` (build nodes), `analyzer.py` (type resolution + coercion `Cast` insertion), `evaluator.py` (execution), `coercion.py` (Spark coercion rules over PySpark types) + unit tests.
- **`column` / `functions`**: the build-phase surface now constructs AST nodes (`col`, `lit`, `when`, arithmetic/comparison/logical operators, `alias`, `cast`, …).
- **`DataFrame.select` / `to_records`** wired through analyze → evaluate; remaining operations stay raising slots.
- **Gate**: drain `arithmetic.same_type` + `arithmetic.numeric_plus_string` from `PYTHON_NOT_IMPLEMENTED`; high-water mark **167 → 165**.
- **Docs**: ARCHITECTURE build→analyze→evaluate section + generic per-engine file table; #104 resolved decisions in the design doc; `known_gaps` clarification.

## Verification

- `make test f=sparkleframe/python` — 208 passed (analyzer / evaluator / coercion / dataframe / column / functions).
- `make test f=sparkleframe/tests/parity/arithmetic_parity_test.py` — `int_plus_int[PYTHON]` + `double_plus_string[PYTHON]` PASS; `double_plus_string[POLARS]` xfails.
- `make test f=sparkleframe/tests/parity` — 0 failed, `gate_ratchet` 165 == 165.
- `make black` + `make lint` — clean.

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)