### PR TITLE
feat(python): scaffold the pure-Python engine package

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,7 @@ cluster**. It is a **partial shim** targeting the **PySpark / Apache Spark 4.x**
 not every operation is supported, but behavior matches Spark where implemented.
 
 It runs on a **pluggable engine**. Polars is the engine today (`sparkleframe/polarsdf`); a
-pure-Python engine is planned (`sparkleframe/python`, #102). The engine is selected via the
+pure-Python engine is scaffolded (`sparkleframe/python`, #102). The engine is selected via the
 `Engine` enum and bound by `activate()`. See [ARCHITECTURE.md](ARCHITECTURE.md) for the map.
 
 ## Hard invariants (always true — don't violate without explicit instruction)

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -31,7 +31,7 @@ is the scoped form. Users can also import an engine package directly and skip ac
 ### An engine package — the API surface
 
 An engine lives under `sparkleframe/<engine>/`. Polars is the only one implemented today
-(`sparkleframe/polarsdf`); `sparkleframe/python` is planned (#102). Within a package, the public
+(`sparkleframe/polarsdf`); `sparkleframe/python` is scaffolded (#102). Within a package, the public
 modules are **thin facades** and all real logic sits in a matching `*_helpers.py`. That split is
 an invariant, not a style preference (see Invariants below).
 
@@ -85,7 +85,7 @@ flowchart TD
     user["user code: import pyspark.sql / sparkleframe.&lt;engine&gt;"]
     activate["activate.py — rebinds sys.modules to the chosen engine"]
     engineenum["engine.py — Engine enum (POLARS, PYTHON)"]
-    pkg["sparkleframe/&lt;engine&gt;/ (polarsdf today, python planned)"]
+    pkg["sparkleframe/&lt;engine&gt;/ (polarsdf today, python scaffolded)"]
     facade["public facades: functions.py / column.py / dataframe.py"]
     helpers["*_helpers.py — coercion, parsing, strict/lenient logic"]
     prim["engine primitives (Column wraps one expr, DataFrame one frame)"]
@@ -124,9 +124,9 @@ flowchart TD
   at *expression-build time*, before the frame schema is known. Cross-type coercion (e.g.
   `col(float) + col(string)`) therefore can't fire for bare column references, which is the root
   cause behind most of `docs/known_gaps.md`. Engines are free to resolve types differently behind
-  the `EngineAdapter` / `Engine` boundary. The planned `python` engine resolves this differently —
+  the `EngineAdapter` / `Engine` boundary. The scaffolded `python` engine resolves this differently —
   see `docs/design/python-engine-ast.md` and #104. (No design detail here, by intent.)
-- **Multiple engines.** The canonical name for the planned pure-Python engine is **`python`**
+- **Multiple engines.** The canonical name for the scaffolded pure-Python engine is **`python`**
   (package `sparkleframe/python/`), consistent across `engine.py`, `gaps.py`, and the docs
   generator. Note: issues #102/#104 and the `feature/pythondf-backend` branch use `pythondf`; those
   external references should be reconciled to `python`.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 SparkleFrame implements the PySpark DataFrame API so you can run transformation pipelines on a lightweight
 **engine** instead of a Spark cluster—no Spark cluster or Spark dependencies required. The engine is pluggable:
-[Polars](https://docs.pola.rs/api/python/stable/reference/index.html) today, with a pure-Python engine planned.
+[Polars](https://docs.pola.rs/api/python/stable/reference/index.html) today, with a pure-Python engine scaffolded.
 It is a **partial** **shim** aimed at the **PySpark / Apache Spark 4.x** DataFrame API: not every operation or
 edge case is supported, but behavior matches Spark where implemented.
 

--- a/docs/contributing/engines.md
+++ b/docs/contributing/engines.md
@@ -23,7 +23,7 @@ rebinds `sys.modules["pyspark.sql"]` (and submodules) to it, so existing `import
 on the engine. Selecting an engine that isn't scaffolded raises `NotImplementedError`.
 
 Only the **Polars** engine (`sparkleframe/polarsdf`) is implemented today. The **`python`** engine
-(`sparkleframe/python`) is planned — see [#102](https://github.com/flypipe/sparkleframe/issues/102)
+(`sparkleframe/python`) is scaffolded — see [#102](https://github.com/flypipe/sparkleframe/issues/102)
 and the design in [../design/python-engine-ast.md](../design/python-engine-ast.md).
 
 ## The parity harness

--- a/docs/design/python-engine-ast.md
+++ b/docs/design/python-engine-ast.md
@@ -1,6 +1,6 @@
 # Design: AST-based type resolution for the Python engine
 
-> This describes a design for the planned pure-Python engine (`sparkleframe/python`,
+> This describes a design for the scaffolded pure-Python engine (`sparkleframe/python`,
 > [#102](https://github.com/flypipe/sparkleframe/issues/102)). It is forward-looking and
 > will change as the engine lands. It is intentionally kept out of `ARCHITECTURE.md`, which
 > maps what exists today. Tracking issue: [#104](https://github.com/flypipe/sparkleframe/issues/104).

--- a/sparkleframe/activate_test.py
+++ b/sparkleframe/activate_test.py
@@ -49,10 +49,17 @@ class TestActivate:
 
         assert pysql.__name__ == "sparkleframe.polarsdf"
 
-    def test_activate_python_engine_raises_not_implemented(self):
-        # The python engine package does not exist yet, so selecting it must fail clearly.
-        with pytest.raises(NotImplementedError):
-            activate(Engine.PYTHON)
+    def test_activate_python_engine_binds_python_engine(self):
+        # The python engine package is now scaffolded, so selecting it binds the namespace.
+        activate(Engine.PYTHON)
+
+        import pyspark.sql as pysql
+
+        assert pysql.__name__ == "sparkleframe.python"
+        # Public PySpark classes are exposed under the rebound namespace.
+        assert hasattr(pysql, "DataFrame")
+        assert hasattr(pysql, "Column")
+        assert hasattr(pysql, "SparkSession")
 
     def test_activate_context_binds_then_restores(self):
         with activate_context():

--- a/sparkleframe/python/__init__.py
+++ b/sparkleframe/python/__init__.py
@@ -1,0 +1,10 @@
+# ruff: noqa: F401
+from sparkleframe.python.column import Column
+from sparkleframe.python.dataframe import DataFrame
+from sparkleframe.python.session import SparkSession
+from sparkleframe.python.window import Window, WindowSpec
+import sparkleframe.python.functions
+import sparkleframe.python.column
+import sparkleframe.python.types
+
+__all__ = ["Column", "SparkSession", "DataFrame", "Window", "WindowSpec"]

--- a/sparkleframe/python/_errors.py
+++ b/sparkleframe/python/_errors.py
@@ -1,0 +1,25 @@
+"""Shared 'not implemented yet' helper for the pure-Python engine scaffolding.
+
+The engine is a walking skeleton: the public surface (functions, Column, DataFrame, …) is
+declared, but every operation raises — the build, analyze, and evaluate phases all land with the
+engine itself. Use this helper so the message is consistent and always points a future
+implementer at the design doc and the build → analyze → evaluate flow.
+"""
+
+from __future__ import annotations
+
+from typing import NoReturn
+
+
+def not_implemented_yet(what: str) -> NoReturn:
+    """Raise a uniform ``NotImplementedError`` for an unimplemented engine behavior.
+
+    Args:
+        what: A short feature id, e.g. ``"DataFrame.select"`` or ``"functions.split"``.
+    """
+    raise NotImplementedError(
+        f"The pure-Python engine does not implement {what} yet. Build the AST node here, then "
+        f"implement its analyze (type resolution) and evaluate (execution) phases, and drain the "
+        f"matching id from PYTHON_NOT_IMPLEMENTED in sparkleframe/tests/parity/gaps.py. "
+        f"See docs/design/python-engine-ast.md."
+    )

--- a/sparkleframe/python/column.py
+++ b/sparkleframe/python/column.py
@@ -1,0 +1,140 @@
+"""``Column`` for the pure-Python engine — a declared surface (walking skeleton).
+
+A :class:`Column` will be the public face of the build phase: its operators and transforms will
+construct unresolved expression-AST nodes that a later analyze → evaluate pass resolves and runs
+(see ``docs/design/python-engine-ast.md``). None of that exists yet — this class is a husk whose
+every operator and transform raises. The build phase, and the AST it produces, land with the
+engine itself.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from sparkleframe.python._errors import not_implemented_yet
+
+
+class Column:
+    def __init__(self) -> None:
+        """No state yet; the wrapped expression arrives with the build phase."""
+
+    # --- Arithmetic ---------------------------------------------------------
+    def __add__(self, other: Any) -> "Column":
+        not_implemented_yet("Column.__add__")
+
+    def __sub__(self, other: Any) -> "Column":
+        not_implemented_yet("Column.__sub__")
+
+    def __mul__(self, other: Any) -> "Column":
+        not_implemented_yet("Column.__mul__")
+
+    def __truediv__(self, other: Any) -> "Column":
+        not_implemented_yet("Column.__truediv__")
+
+    def __pow__(self, other: Any) -> "Column":
+        not_implemented_yet("Column.__pow__")
+
+    def __radd__(self, other: Any) -> "Column":
+        not_implemented_yet("Column.__radd__")
+
+    def __rsub__(self, other: Any) -> "Column":
+        not_implemented_yet("Column.__rsub__")
+
+    def __rmul__(self, other: Any) -> "Column":
+        not_implemented_yet("Column.__rmul__")
+
+    def __rtruediv__(self, other: Any) -> "Column":
+        not_implemented_yet("Column.__rtruediv__")
+
+    def __rpow__(self, other: Any) -> "Column":
+        not_implemented_yet("Column.__rpow__")
+
+    def __neg__(self) -> "Column":
+        not_implemented_yet("Column.__neg__")
+
+    def __pos__(self) -> "Column":
+        not_implemented_yet("Column.__pos__")
+
+    # --- Comparison ---------------------------------------------------------
+    def __eq__(self, other: Any) -> "Column":  # type: ignore[override]
+        not_implemented_yet("Column.__eq__")
+
+    def __ne__(self, other: Any) -> "Column":  # type: ignore[override]
+        not_implemented_yet("Column.__ne__")
+
+    def __lt__(self, other: Any) -> "Column":
+        not_implemented_yet("Column.__lt__")
+
+    def __le__(self, other: Any) -> "Column":
+        not_implemented_yet("Column.__le__")
+
+    def __gt__(self, other: Any) -> "Column":
+        not_implemented_yet("Column.__gt__")
+
+    def __ge__(self, other: Any) -> "Column":
+        not_implemented_yet("Column.__ge__")
+
+    # Column overrides __eq__, so it is unhashable by default — mirror PySpark.
+    __hash__ = None  # type: ignore[assignment]
+
+    # --- Logical ------------------------------------------------------------
+    def __and__(self, other: Any) -> "Column":
+        not_implemented_yet("Column.__and__")
+
+    def __rand__(self, other: Any) -> "Column":
+        not_implemented_yet("Column.__rand__")
+
+    def __or__(self, other: Any) -> "Column":
+        not_implemented_yet("Column.__or__")
+
+    def __ror__(self, other: Any) -> "Column":
+        not_implemented_yet("Column.__ror__")
+
+    def __invert__(self) -> "Column":
+        not_implemented_yet("Column.__invert__")
+
+    # --- Transforms ---------------------------------------------------------
+    def alias(self, name: str) -> "Column":
+        not_implemented_yet("Column.alias")
+
+    def cast(self, data_type: Any) -> "Column":
+        not_implemented_yet("Column.cast")
+
+    def try_cast(self, data_type: Any) -> "Column":
+        not_implemented_yet("Column.try_cast")
+
+    def isNull(self) -> "Column":
+        not_implemented_yet("Column.isNull")
+
+    def isNotNull(self) -> "Column":
+        not_implemented_yet("Column.isNotNull")
+
+    def isin(self, *values: Any) -> "Column":
+        not_implemented_yet("Column.isin")
+
+    def rlike(self, pattern: str) -> "Column":
+        not_implemented_yet("Column.rlike")
+
+    def contains(self, substring: str) -> "Column":
+        not_implemented_yet("Column.contains")
+
+    def getItem(self, key: Any) -> "Column":
+        not_implemented_yet("Column.getItem")
+
+    def __getitem__(self, key: Any) -> "Column":
+        not_implemented_yet("Column.__getitem__")
+
+    def asc(self) -> "Column":
+        not_implemented_yet("Column.asc")
+
+    def desc(self) -> "Column":
+        not_implemented_yet("Column.desc")
+
+    def asc_nulls_last(self) -> "Column":
+        not_implemented_yet("Column.asc_nulls_last")
+
+    def desc_nulls_last(self) -> "Column":
+        not_implemented_yet("Column.desc_nulls_last")
+
+    def __repr__(self) -> str:
+        return "Column()"

--- a/sparkleframe/python/column_helpers.py
+++ b/sparkleframe/python/column_helpers.py
@@ -1,0 +1,9 @@
+"""Shared, private helpers for ``column.py`` (pure-Python engine).
+
+Placeholder: per the repo convention (CLAUDE.md), shared/private logic for the public
+``column`` surface lives here rather than in ``column.py``. Build-phase node construction is
+trivial enough to stay inline today; coercion/resolution helpers used by the analyze and
+evaluate phases will land here as features are implemented.
+"""
+
+from __future__ import annotations

--- a/sparkleframe/python/column_test.py
+++ b/sparkleframe/python/column_test.py
@@ -1,0 +1,71 @@
+"""Unit tests for ``Column`` — a declared husk whose every operator and transform raises."""
+
+import pytest
+
+import sparkleframe.python.column_helpers as column_helpers
+from sparkleframe.python.column import Column
+
+
+class TestColumnConstruction:
+    def test_constructs(self):
+        assert isinstance(Column(), Column)
+
+    def test_repr(self):
+        assert "Column" in repr(Column())
+
+    def test_is_unhashable_like_pyspark(self):
+        with pytest.raises(TypeError):
+            hash(Column())
+
+
+class TestColumnOpsRaise:
+    @pytest.mark.parametrize(
+        "call",
+        [
+            lambda c: c + 1,
+            lambda c: c - 1,
+            lambda c: c * 2,
+            lambda c: c / 2,
+            lambda c: c**2,
+            lambda c: 1 + c,
+            lambda c: 1 - c,
+            lambda c: 2 * c,
+            lambda c: 2 / c,
+            lambda c: 2**c,
+            lambda c: -c,
+            lambda c: +c,
+            lambda c: ~c,
+            lambda c: c == 1,
+            lambda c: c != 1,
+            lambda c: c < 1,
+            lambda c: c <= 1,
+            lambda c: c > 1,
+            lambda c: c >= 1,
+            lambda c: c & Column(),
+            lambda c: c | Column(),
+            lambda c: Column() & c,
+            lambda c: Column() | c,
+            lambda c: c.alias("b"),
+            lambda c: c.cast("int"),
+            lambda c: c.try_cast("int"),
+            lambda c: c.isNull(),
+            lambda c: c.isNotNull(),
+            lambda c: c.isin(1, 2),
+            lambda c: c.rlike("x"),
+            lambda c: c.contains("x"),
+            lambda c: c.getItem("k"),
+            lambda c: c["k"],
+            lambda c: c.asc(),
+            lambda c: c.desc(),
+            lambda c: c.asc_nulls_last(),
+            lambda c: c.desc_nulls_last(),
+        ],
+    )
+    def test_op_raises(self, call):
+        with pytest.raises(NotImplementedError):
+            call(Column())
+
+
+def test_column_helpers_module_importable():
+    # Placeholder module for shared column logic; assert it loads.
+    assert isinstance(column_helpers.__name__, str)

--- a/sparkleframe/python/dataframe.py
+++ b/sparkleframe/python/dataframe.py
@@ -1,0 +1,107 @@
+"""``DataFrame`` for the pure-Python engine — a walking skeleton.
+
+The constructor stores the rows and the (PySpark) schema verbatim — that is the data the
+build → analyze → evaluate flow will consume. Every transformation and action is a raising slot
+for now; they land incrementally as the analyze (type resolution) and evaluate (execution) phases
+are implemented (see ``docs/design/python-engine-ast.md``).
+
+Type handling: per the engine's first-pass decision the schema is a PySpark ``StructType``
+consumed directly (see ``docs/design/python-engine-ast.md`` and the plan).
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional, Tuple, Union
+
+from sparkleframe.base.dataframe import DataFrame as BaseDataFrame
+from sparkleframe.python._errors import not_implemented_yet
+from sparkleframe.python.column import Column
+
+
+class DataFrame(BaseDataFrame):
+    def __init__(self, data: Any, schema: Optional[Any] = None) -> None:
+        super().__init__(df=None)
+        # Stored verbatim for the analyze/evaluate phases to consume.
+        self._rows: list = list(data) if data is not None else []
+        self._schema = schema
+
+    def to_records(self) -> list:
+        not_implemented_yet("DataFrame.to_records")
+
+    def columns(self) -> List[str]:
+        not_implemented_yet("DataFrame.columns")
+
+    def schema(self) -> Any:
+        not_implemented_yet("DataFrame.schema")
+
+    def dtypes(self) -> List[Tuple[str, str]]:
+        not_implemented_yet("DataFrame.dtypes")
+
+    def __getitem__(self, item: Union[int, str, Column, List, Tuple]) -> Union[Column, "DataFrame"]:
+        not_implemented_yet("DataFrame.__getitem__")
+
+    def alias(self, name: str) -> "DataFrame":
+        not_implemented_yet("DataFrame.alias")
+
+    def select(self, *cols: Union[str, Column, List[str], List[Column]]) -> "DataFrame":
+        not_implemented_yet("DataFrame.select")
+
+    def filter(self, condition: Union[str, Column]) -> "DataFrame":
+        not_implemented_yet("DataFrame.filter")
+
+    def where(self, condition: Union[str, Column]) -> "DataFrame":
+        not_implemented_yet("DataFrame.where")
+
+    def withColumn(self, name: str, col: Any) -> "DataFrame":
+        not_implemented_yet("DataFrame.withColumn")
+
+    def withColumns(self, colsMap: dict[str, Column]) -> "DataFrame":
+        not_implemented_yet("DataFrame.withColumns")
+
+    def withColumnRenamed(self, existing: str, new: str) -> "DataFrame":
+        not_implemented_yet("DataFrame.withColumnRenamed")
+
+    def drop(self, *cols: Union[str, Column]) -> "DataFrame":
+        not_implemented_yet("DataFrame.drop")
+
+    def distinct(self) -> "DataFrame":
+        not_implemented_yet("DataFrame.distinct")
+
+    def dropDuplicates(self, subset: Optional[List[str]] = None) -> "DataFrame":
+        not_implemented_yet("DataFrame.dropDuplicates")
+
+    def union(self, other: "DataFrame") -> "DataFrame":
+        not_implemented_yet("DataFrame.union")
+
+    def unionByName(self, other: "DataFrame", allowMissingColumns: bool = False) -> "DataFrame":
+        not_implemented_yet("DataFrame.unionByName")
+
+    def join(self, other: "DataFrame", on: Any = None, how: str = "inner") -> "DataFrame":
+        not_implemented_yet("DataFrame.join")
+
+    def groupBy(self, *cols: Union[str, Column]) -> Any:
+        not_implemented_yet("DataFrame.groupBy")
+
+    def groupby(self, *cols: Union[str, Column]) -> Any:
+        not_implemented_yet("DataFrame.groupby")
+
+    def sort(self, *cols: Union[str, Column, int, List[Union[str, Column, int]]]) -> "DataFrame":
+        not_implemented_yet("DataFrame.sort")
+
+    def orderBy(self, *cols: Union[str, Column, int, List[Union[str, Column, int]]]) -> "DataFrame":
+        not_implemented_yet("DataFrame.orderBy")
+
+    def fillna(self, value: Union[Any, dict], subset: Union[str, List[str], None] = None) -> "DataFrame":
+        not_implemented_yet("DataFrame.fillna")
+
+    def count(self) -> int:
+        not_implemented_yet("DataFrame.count")
+
+    def show(self, n: int = 20, truncate: bool = True, vertical: bool = False) -> None:
+        not_implemented_yet("DataFrame.show")
+
+    def toPandas(self) -> Any:
+        not_implemented_yet("DataFrame.toPandas")
+
+    def to_arrow(self) -> Any:
+        not_implemented_yet("DataFrame.to_arrow")

--- a/sparkleframe/python/dataframe_helpers.py
+++ b/sparkleframe/python/dataframe_helpers.py
@@ -1,0 +1,6 @@
+"""Shared, private helpers for ``dataframe.py`` (pure-Python engine).
+
+Per the repo convention (CLAUDE.md), shared/private logic for the public ``dataframe`` surface
+lives here rather than in ``dataframe.py``. Empty for now — helpers land alongside the DataFrame
+operations they support as the analyze/evaluate phases are implemented.
+"""

--- a/sparkleframe/python/dataframe_test.py
+++ b/sparkleframe/python/dataframe_test.py
@@ -1,0 +1,62 @@
+"""Unit tests for ``DataFrame``: the constructor stores state; every action is a slot that raises."""
+
+import pytest
+
+import sparkleframe.python.dataframe_helpers as dataframe_helpers
+from sparkleframe.python.dataframe import DataFrame
+
+
+class TestDataFrameConstruction:
+    def test_stores_rows_and_schema(self):
+        rows = [(1, 2), (3, 4)]
+        df = DataFrame(rows, schema="schema-sentinel")
+        assert df._rows == rows
+        assert df._schema == "schema-sentinel"
+
+    def test_none_data_becomes_empty(self):
+        df = DataFrame(None)
+        assert df._rows == []
+        assert df._schema is None
+
+
+class TestDataFrameActionsRaise:
+    @pytest.mark.parametrize(
+        "call",
+        [
+            lambda df: df.to_records(),
+            lambda df: df.columns(),
+            lambda df: df.schema(),
+            lambda df: df.dtypes(),
+            lambda df: df["a"],
+            lambda df: df.alias("x"),
+            lambda df: df.select("a"),
+            lambda df: df.filter("a > 1"),
+            lambda df: df.where("a > 1"),
+            lambda df: df.withColumn("b", None),
+            lambda df: df.withColumns({}),
+            lambda df: df.withColumnRenamed("a", "b"),
+            lambda df: df.drop("a"),
+            lambda df: df.distinct(),
+            lambda df: df.dropDuplicates(),
+            lambda df: df.union(df),
+            lambda df: df.unionByName(df),
+            lambda df: df.join(df),
+            lambda df: df.groupBy("a"),
+            lambda df: df.groupby("a"),
+            lambda df: df.sort("a"),
+            lambda df: df.orderBy("a"),
+            lambda df: df.fillna(0),
+            lambda df: df.count(),
+            lambda df: df.show(),
+            lambda df: df.toPandas(),
+            lambda df: df.to_arrow(),
+        ],
+    )
+    def test_action_raises(self, call):
+        df = DataFrame([(1,)], schema=None)
+        with pytest.raises(NotImplementedError):
+            call(df)
+
+
+def test_dataframe_helpers_module_importable():
+    assert isinstance(dataframe_helpers.__name__, str)

--- a/sparkleframe/python/functions.py
+++ b/sparkleframe/python/functions.py
@@ -1,0 +1,297 @@
+"""``pyspark.sql.functions`` surface for the pure-Python engine — a declared surface (walking skeleton).
+
+Each function will be part of the build phase: it will construct an unresolved expression-AST node
+that a later analyze → evaluate pass resolves and runs (see ``docs/design/python-engine-ast.md``).
+None of that exists yet — every function here is a declared slot that raises, documenting the
+surface so it can be filled in (and the matching id drained from the Python parity gate in
+``sparkleframe/tests/parity/gaps.py``) as the engine lands.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Optional, Union
+
+from sparkleframe.python._errors import not_implemented_yet
+from sparkleframe.python.column import Column
+
+
+# --- Column builders --------------------------------------------------------
+def col(name: str) -> Column:
+    not_implemented_yet("functions.col")
+
+
+def lit(value: Any) -> Column:
+    not_implemented_yet("functions.lit")
+
+
+def when(condition: Any, value: Any) -> Column:
+    not_implemented_yet("functions.when")
+
+
+# --- Remaining surface (slots) ----------------------------------------------
+def abs(col_name: Union[str, Column]) -> Column:
+    not_implemented_yet("functions.abs")
+
+
+def lower(col_name: Union[str, Column]) -> Column:
+    not_implemented_yet("functions.lower")
+
+
+def count(col_name: Union[str, Column]) -> Column:
+    not_implemented_yet("functions.count")
+
+
+def coalesce(*cols: Union[str, Column]) -> Column:
+    not_implemented_yet("functions.coalesce")
+
+
+def get_json_object(col: Union[str, Column], path: str) -> Column:
+    not_implemented_yet("functions.get_json_object")
+
+
+def from_json(col_name: Union[str, Column], schema: Union[Any, str]) -> Column:
+    not_implemented_yet("functions.from_json")
+
+
+def to_json(col_name: Union[str, Column], options: Any = None) -> Column:
+    not_implemented_yet("functions.to_json")
+
+
+def least(*cols: Any) -> Column:
+    not_implemented_yet("functions.least")
+
+
+def greatest(*cols: Any) -> Column:
+    not_implemented_yet("functions.greatest")
+
+
+def sum(col_name: Union[str, Column]) -> Column:
+    not_implemented_yet("functions.sum")
+
+
+def mean(col_name: Union[str, Column]) -> Column:
+    not_implemented_yet("functions.mean")
+
+
+def min(col_name: Union[str, Column]) -> Column:
+    not_implemented_yet("functions.min")
+
+
+def max(col_name: Union[str, Column]) -> Column:
+    not_implemented_yet("functions.max")
+
+
+def first(col_name: Union[str, Column], ignorenulls: bool = False) -> Column:
+    not_implemented_yet("functions.first")
+
+
+def map_from_entries(col_name: Union[str, Column]) -> Column:
+    not_implemented_yet("functions.map_from_entries")
+
+
+def create_map(*cols: Any) -> Column:
+    not_implemented_yet("functions.create_map")
+
+
+def array(*cols: Any) -> Column:
+    not_implemented_yet("functions.array")
+
+
+def map_keys(col_name: Union[str, Column]) -> Column:
+    not_implemented_yet("functions.map_keys")
+
+
+def collect_list(col_name: Union[str, Column]) -> Column:
+    not_implemented_yet("functions.collect_list")
+
+
+def collect_set(col_name: Union[str, Column]) -> Column:
+    not_implemented_yet("functions.collect_set")
+
+
+def transform(col_name: Union[str, Column], func: Callable[[Column], Any]) -> Column:
+    not_implemented_yet("functions.transform")
+
+
+def round(col_name: Union[str, Column], scale: int = 0) -> Column:
+    not_implemented_yet("functions.round")
+
+
+def to_timestamp(col_name: Union[str, Column], fmt: Optional[str] = None) -> Column:
+    not_implemented_yet("functions.to_timestamp")
+
+
+def date_format(col_name: Union[str, Column], fmt: str) -> Column:
+    not_implemented_yet("functions.date_format")
+
+
+def regexp_replace(col_name: Union[str, Column], pattern: str, replacement: str) -> Column:
+    not_implemented_yet("functions.regexp_replace")
+
+
+def length(col_name: Union[str, Column]) -> Column:
+    not_implemented_yet("functions.length")
+
+
+def asc(column: Union[str, Column]) -> Column:
+    not_implemented_yet("functions.asc")
+
+
+def asc_nulls_first(column: Union[str, Column]) -> Column:
+    not_implemented_yet("functions.asc_nulls_first")
+
+
+def asc_nulls_last(column: Union[str, Column]) -> Column:
+    not_implemented_yet("functions.asc_nulls_last")
+
+
+def desc(column: Union[str, Column]) -> Column:
+    not_implemented_yet("functions.desc")
+
+
+def desc_nulls_first(column: Union[str, Column]) -> Column:
+    not_implemented_yet("functions.desc_nulls_first")
+
+
+def desc_nulls_last(column: Union[str, Column]) -> Column:
+    not_implemented_yet("functions.desc_nulls_last")
+
+
+def rank() -> Column:
+    not_implemented_yet("functions.rank")
+
+
+def dense_rank() -> Column:
+    not_implemented_yet("functions.dense_rank")
+
+
+def row_number() -> Column:
+    not_implemented_yet("functions.row_number")
+
+
+def floor(col_name: Union[str, Column]) -> Column:
+    not_implemented_yet("functions.floor")
+
+
+def pow(base: Any, exponent: Any) -> Column:
+    not_implemented_yet("functions.pow")
+
+
+def isnan(col_name: Union[str, Column]) -> Column:
+    not_implemented_yet("functions.isnan")
+
+
+def try_divide(left: Union[str, Column], right: Union[str, Column]) -> Column:
+    not_implemented_yet("functions.try_divide")
+
+
+def initcap(col_name: Union[str, Column]) -> Column:
+    not_implemented_yet("functions.initcap")
+
+
+def md5(col_name: Union[str, Column]) -> Column:
+    not_implemented_yet("functions.md5")
+
+
+def trim(col_name: Union[str, Column]) -> Column:
+    not_implemented_yet("functions.trim")
+
+
+def nullif(e1: Union[str, Column], e2: Union[str, Column]) -> Column:
+    not_implemented_yet("functions.nullif")
+
+
+def split(col_name: Union[str, Column], pattern: str, limit: int = -1) -> Column:
+    not_implemented_yet("functions.split")
+
+
+def substring(col_name: Union[str, Column], pos: int, length: int) -> Column:
+    not_implemented_yet("functions.substring")
+
+
+def now() -> Column:
+    not_implemented_yet("functions.now")
+
+
+def monotonically_increasing_id() -> Column:
+    not_implemented_yet("functions.monotonically_increasing_id")
+
+
+def current_timestamp() -> Column:
+    not_implemented_yet("functions.current_timestamp")
+
+
+def current_date() -> Column:
+    not_implemented_yet("functions.current_date")
+
+
+def date_sub(col_name: Union[str, Column], days: int) -> Column:
+    not_implemented_yet("functions.date_sub")
+
+
+def datediff(end: Union[str, Column], start: Union[str, Column]) -> Column:
+    not_implemented_yet("functions.datediff")
+
+
+def months_between(end: Union[str, Column], start: Union[str, Column]) -> Column:
+    not_implemented_yet("functions.months_between")
+
+
+def rand(seed: Optional[int] = None) -> Column:
+    not_implemented_yet("functions.rand")
+
+
+def broadcast(df: Any) -> Any:
+    not_implemented_yet("functions.broadcast")
+
+
+def sort_array(col_name: Union[str, Column], asc: bool = True) -> Column:
+    not_implemented_yet("functions.sort_array")
+
+
+def array_contains(col_name: Union[str, Column], value: Union[str, Column, Any]) -> Column:
+    not_implemented_yet("functions.array_contains")
+
+
+def size(col_name: Union[str, Column]) -> Column:
+    not_implemented_yet("functions.size")
+
+
+def filter(col_name: Union[str, Column], func: Callable[[Column], Any]) -> Column:
+    not_implemented_yet("functions.filter")
+
+
+def explode(col_name: Union[str, Column]) -> Column:
+    not_implemented_yet("functions.explode")
+
+
+def concat(*cols: Union[str, Column]) -> Column:
+    not_implemented_yet("functions.concat")
+
+
+def struct(*cols: Any) -> Column:
+    not_implemented_yet("functions.struct")
+
+
+def try_to_timestamp(col_name: Union[str, Column], fmt: Optional[str] = None) -> Column:
+    not_implemented_yet("functions.try_to_timestamp")
+
+
+def to_date(col_name: Union[str, Column], fmt: Optional[str] = None) -> Column:
+    not_implemented_yet("functions.to_date")
+
+
+def try_to_date(col_name: Union[str, Column], fmt: Optional[str] = None) -> Column:
+    not_implemented_yet("functions.try_to_date")
+
+
+def try_element_at(col_name: Union[str, Column], extraction: Union[str, int, Column]) -> Column:
+    not_implemented_yet("functions.try_element_at")
+
+
+def element_at(col_name: Union[str, Column], extraction: Union[str, int, Column]) -> Column:
+    not_implemented_yet("functions.element_at")
+
+
+def uuid() -> Column:
+    not_implemented_yet("functions.uuid")

--- a/sparkleframe/python/functions_helpers.py
+++ b/sparkleframe/python/functions_helpers.py
@@ -1,0 +1,9 @@
+"""Shared, private helpers for ``functions.py`` (pure-Python engine).
+
+Placeholder: per the repo convention (CLAUDE.md), shared/private logic for the public
+``functions`` surface lives here rather than in ``functions.py``. Date/time parsing,
+JSON/struct, and array/map helpers used by the analyze and evaluate phases will land here as
+the corresponding functions are implemented.
+"""
+
+from __future__ import annotations

--- a/sparkleframe/python/functions_test.py
+++ b/sparkleframe/python/functions_test.py
@@ -1,0 +1,91 @@
+"""Unit tests for the ``functions`` surface — every function is a slot that raises until the engine lands."""
+
+import pytest
+
+import sparkleframe.python.functions as F
+import sparkleframe.python.functions_helpers as functions_helpers
+
+# Every function is a declared slot that raises until implemented. Calling each one (with dummy
+# arguments) both documents the surface and guards that the slot stays wired.
+_UNIMPLEMENTED = [
+    lambda: F.col("a"),
+    lambda: F.lit(5),
+    lambda: F.when(object(), object()),
+    lambda: F.abs("a"),
+    lambda: F.lower("a"),
+    lambda: F.count("a"),
+    lambda: F.coalesce("a", "b"),
+    lambda: F.get_json_object("c", "$.a"),
+    lambda: F.from_json("c", "int"),
+    lambda: F.to_json("c"),
+    lambda: F.least("a", "b"),
+    lambda: F.greatest("a", "b"),
+    lambda: F.sum("a"),
+    lambda: F.mean("a"),
+    lambda: F.min("a"),
+    lambda: F.max("a"),
+    lambda: F.first("a"),
+    lambda: F.map_from_entries("a"),
+    lambda: F.create_map("a", "b"),
+    lambda: F.array("a", "b"),
+    lambda: F.map_keys("a"),
+    lambda: F.collect_list("a"),
+    lambda: F.collect_set("a"),
+    lambda: F.transform("a", lambda x: x),
+    lambda: F.round("a", 1),
+    lambda: F.to_timestamp("a"),
+    lambda: F.date_format("a", "yyyy"),
+    lambda: F.regexp_replace("a", "x", "y"),
+    lambda: F.length("a"),
+    lambda: F.asc("a"),
+    lambda: F.asc_nulls_first("a"),
+    lambda: F.asc_nulls_last("a"),
+    lambda: F.desc("a"),
+    lambda: F.desc_nulls_first("a"),
+    lambda: F.desc_nulls_last("a"),
+    lambda: F.rank(),
+    lambda: F.dense_rank(),
+    lambda: F.row_number(),
+    lambda: F.floor("a"),
+    lambda: F.pow("a", "b"),
+    lambda: F.isnan("a"),
+    lambda: F.try_divide("a", "b"),
+    lambda: F.initcap("a"),
+    lambda: F.md5("a"),
+    lambda: F.trim("a"),
+    lambda: F.nullif("a", "b"),
+    lambda: F.split("a", ","),
+    lambda: F.substring("a", 1, 2),
+    lambda: F.now(),
+    lambda: F.monotonically_increasing_id(),
+    lambda: F.current_timestamp(),
+    lambda: F.current_date(),
+    lambda: F.date_sub("a", 1),
+    lambda: F.datediff("a", "b"),
+    lambda: F.months_between("a", "b"),
+    lambda: F.rand(),
+    lambda: F.broadcast(object()),
+    lambda: F.sort_array("a"),
+    lambda: F.array_contains("a", 1),
+    lambda: F.size("a"),
+    lambda: F.filter("a", lambda x: x),
+    lambda: F.explode("a"),
+    lambda: F.concat("a", "b"),
+    lambda: F.struct("a", "b"),
+    lambda: F.try_to_timestamp("a"),
+    lambda: F.to_date("a"),
+    lambda: F.try_to_date("a"),
+    lambda: F.try_element_at("a", 1),
+    lambda: F.element_at("a", 1),
+    lambda: F.uuid(),
+]
+
+
+@pytest.mark.parametrize("call", _UNIMPLEMENTED)
+def test_functions_raise(call):
+    with pytest.raises(NotImplementedError):
+        call()
+
+
+def test_functions_helpers_module_importable():
+    assert isinstance(functions_helpers.__name__, str)

--- a/sparkleframe/python/group.py
+++ b/sparkleframe/python/group.py
@@ -1,0 +1,39 @@
+"""``GroupedData`` for the pure-Python engine — produced by ``DataFrame.groupBy``.
+
+The constructor stores the grouping columns; the aggregations are slots that raise until the
+analyze/evaluate phases land.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Union
+
+from sparkleframe.python._errors import not_implemented_yet
+from sparkleframe.python.column import Column
+
+if TYPE_CHECKING:  # avoid a runtime import cycle with dataframe.py
+    from sparkleframe.python.dataframe import DataFrame
+
+
+class GroupedData:
+    def __init__(self, df: "DataFrame", group_cols: list[Union[str, Column]]) -> None:
+        self.df = df
+        self.group_cols = group_cols
+
+    def agg(self, *exprs: Union[str, Column]) -> "DataFrame":
+        not_implemented_yet("GroupedData.agg")
+
+    def count(self) -> "DataFrame":
+        not_implemented_yet("GroupedData.count")
+
+    def sum(self) -> "DataFrame":
+        not_implemented_yet("GroupedData.sum")
+
+    def mean(self) -> "DataFrame":
+        not_implemented_yet("GroupedData.mean")
+
+    def max(self) -> "DataFrame":
+        not_implemented_yet("GroupedData.max")
+
+    def min(self) -> "DataFrame":
+        not_implemented_yet("GroupedData.min")

--- a/sparkleframe/python/group_test.py
+++ b/sparkleframe/python/group_test.py
@@ -1,0 +1,33 @@
+"""Unit tests for ``GroupedData`` — the constructor stores state; aggregations are slots that raise."""
+
+import pytest
+
+from sparkleframe.python.dataframe import DataFrame
+from sparkleframe.python.group import GroupedData
+
+
+def _grouped() -> GroupedData:
+    return GroupedData(DataFrame([(1,)], schema=None), ["a"])
+
+
+def test_constructor_stores_state():
+    df = DataFrame([(1,)], schema=None)
+    grouped = GroupedData(df, ["a", "b"])
+    assert grouped.df is df
+    assert grouped.group_cols == ["a", "b"]
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda g: g.agg("a"),
+        lambda g: g.count(),
+        lambda g: g.sum(),
+        lambda g: g.mean(),
+        lambda g: g.max(),
+        lambda g: g.min(),
+    ],
+)
+def test_aggregations_raise(call):
+    with pytest.raises(NotImplementedError):
+        call(_grouped())

--- a/sparkleframe/python/session.py
+++ b/sparkleframe/python/session.py
@@ -1,0 +1,44 @@
+"""``SparkSession`` for the pure-Python engine.
+
+Mirrors :mod:`sparkleframe.polarsdf.session`: the builder and ``createDataFrame`` entry point
+are wired (they just construct a :class:`~sparkleframe.python.dataframe.DataFrame`); the frame's
+operations are where the unimplemented work lives.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+from sparkleframe.python.dataframe import DataFrame
+
+
+class SparkSession:
+    def __init__(self) -> None:
+        self.appName_str = ""
+        self.master_str = ""
+
+    def createDataFrame(self, data: Any, schema: Optional[Any] = None) -> DataFrame:
+        return DataFrame(data, schema=schema)
+
+    class Builder:
+        def appName(self, name: str) -> "SparkSession.Builder":
+            self.appName_str = name
+            return self
+
+        def master(self, master_str: str) -> "SparkSession.Builder":
+            self.master_str = master_str
+            return self
+
+        def getOrCreate(self) -> "SparkSession":
+            return SparkSession()
+
+        def config(self, key: Any, value: Any) -> "SparkSession.Builder":
+            return self
+
+    builder = Builder()
+
+    class SparkContext:
+        def setLogLevel(self, level: Any) -> None:
+            pass
+
+    sparkContext = SparkContext()

--- a/sparkleframe/python/session_test.py
+++ b/sparkleframe/python/session_test.py
@@ -1,0 +1,19 @@
+"""Unit tests for ``SparkSession`` — the builder and ``createDataFrame`` entry point are wired."""
+
+from sparkleframe.python.dataframe import DataFrame
+from sparkleframe.python.session import SparkSession
+
+
+class TestSparkSession:
+    def test_builder_chain_returns_session(self):
+        session = SparkSession.builder.appName("app").master("local").config("k", "v").getOrCreate()
+        assert isinstance(session, SparkSession)
+
+    def test_create_dataframe_returns_dataframe(self):
+        session = SparkSession()
+        df = session.createDataFrame([(1, 2)], schema=None)
+        assert isinstance(df, DataFrame)
+        assert df._rows == [(1, 2)]
+
+    def test_spark_context_set_log_level_is_noop(self):
+        assert SparkSession.sparkContext.setLogLevel("INFO") is None

--- a/sparkleframe/python/types.py
+++ b/sparkleframe/python/types.py
@@ -1,0 +1,36 @@
+"""Type handling for the pure-Python engine.
+
+First-pass decision (see the plan and ``docs/design/python-engine-ast.md``): the engine
+consumes PySpark ``DataType`` / ``StructType`` objects **directly**. The parity adapter passes
+the Spark schema straight through, so no per-engine type registry exists yet (unlike
+``polarsdf/types.py``); add one only when the engine needs its own type identities.
+
+The common PySpark type names are re-exported here for API compatibility. The import is guarded
+because under ``activate()`` the real ``pyspark`` package is replaced by a mock, and the engine
+must still import cleanly.
+"""
+
+from __future__ import annotations
+
+try:  # pragma: no cover - exercised only with the real pyspark installed
+    from pyspark.sql.types import (  # noqa: F401
+        ArrayType,
+        BinaryType,
+        BooleanType,
+        ByteType,
+        DataType,
+        DateType,
+        DecimalType,
+        DoubleType,
+        FloatType,
+        IntegerType,
+        LongType,
+        MapType,
+        ShortType,
+        StringType,
+        StructField,
+        StructType,
+        TimestampType,
+    )
+except Exception:  # pragma: no cover - mock pyspark (under activate) has no real types
+    pass

--- a/sparkleframe/python/window.py
+++ b/sparkleframe/python/window.py
@@ -1,0 +1,37 @@
+"""``Window`` / ``WindowSpec`` for the pure-Python engine.
+
+Declared so the public surface matches PySpark; the partition/order/frame builders are slots
+that raise until window functions are implemented in the analyze/evaluate phases.
+"""
+
+from __future__ import annotations
+
+from typing import List, Union
+
+from sparkleframe.python._errors import not_implemented_yet
+from sparkleframe.python.column import Column
+
+
+class WindowSpec:
+    def __init__(self) -> None:
+        self._partition_cols: List[Union[str, Column]] = []
+        self._order_cols: List[Union[str, Column]] = []
+
+    def partitionBy(self, *cols: Union[str, Column]) -> "WindowSpec":
+        not_implemented_yet("WindowSpec.partitionBy")
+
+    def orderBy(self, *cols: Union[str, Column]) -> "WindowSpec":
+        not_implemented_yet("WindowSpec.orderBy")
+
+    def rangeBetween(self, start: int, end: int) -> "WindowSpec":
+        not_implemented_yet("WindowSpec.rangeBetween")
+
+
+class Window:
+    @staticmethod
+    def partitionBy(*cols: Union[str, Column]) -> WindowSpec:
+        not_implemented_yet("Window.partitionBy")
+
+    @staticmethod
+    def orderBy(*cols: Union[str, Column]) -> WindowSpec:
+        not_implemented_yet("Window.orderBy")

--- a/sparkleframe/python/window_test.py
+++ b/sparkleframe/python/window_test.py
@@ -1,0 +1,26 @@
+"""Unit tests for ``Window`` / ``WindowSpec`` — declared surface; builders are slots that raise."""
+
+import pytest
+
+from sparkleframe.python.window import Window, WindowSpec
+
+
+def test_window_spec_constructs_empty():
+    spec = WindowSpec()
+    assert spec._partition_cols == []
+    assert spec._order_cols == []
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda: WindowSpec().partitionBy("a"),
+        lambda: WindowSpec().orderBy("a"),
+        lambda: WindowSpec().rangeBetween(0, 1),
+        lambda: Window.partitionBy("a"),
+        lambda: Window.orderBy("a"),
+    ],
+)
+def test_builders_raise(call):
+    with pytest.raises(NotImplementedError):
+        call()


### PR DESCRIPTION
## What

Introduces `sparkleframe/python` as a **walking skeleton** for the pluggable pure-Python engine — the scaffold half of the work previously bundled in #107. The follow-up PR (#107, rebased on top of this) carries the actual build → analyze → evaluate engine.

The package **declares the full public surface** — `functions`, `Column`, `DataFrame`, `SparkSession`, `GroupedData`, `Window` — but **every operation raises** via the shared `_errors.not_implemented_yet` helper. There is no expression AST and no build/analyze/evaluate logic here; that all lands with the engine itself.

## Contents

- **`functions` / `Column`**: every function and operator is a declared slot that raises — documenting the surface without implementing it.
- **`DataFrame`** stores rows + schema verbatim; all actions raise.
- **`SparkSession`**: the builder chain and `createDataFrame` are wired (they just construct a `DataFrame`).
- **`activate(Engine.PYTHON)`** now binds the python namespace (the package exists) — see `activate_test.py`.
- **Docs**: flip the python-engine wording from "planned" to "scaffolded".
- **No `ast/` subpackage, no coercion** — those arrive in the follow-up.

## Gate

No `gaps.py` change — the gate stays at **167**. Every `[PYTHON]` parity param `xfail`s; `gate_ratchet` holds at 167.

## Verification

- `make test f=sparkleframe/python` — 158 passed (every slot raises as asserted).
- `make test f=sparkleframe/tests/parity` — 0 failed, all `[PYTHON]` xfail, `gate_ratchet` 167 == 167.
- `make test f=sparkleframe/activate_test.py` — python namespace binds.
- `make black` + `make lint` — clean.

Relates to #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)